### PR TITLE
esn-frontend-calendar#19: Fixed broken subheader UI in mobile

### DIFF
--- a/src/linagora.esn.calendar/app/calendar/calendar-header/calendar-sub-header.less
+++ b/src/linagora.esn.calendar/app/calendar/calendar-header/calendar-sub-header.less
@@ -2,6 +2,8 @@
   width: 100%;
 
   .calendar-controls {
+    display: flex;
+
     transition: 1s background;
     .btn {
       box-shadow: none;


### PR DESCRIPTION
- Before:

![BrokenSubheaderUIMobile_Before](https://user-images.githubusercontent.com/24670327/88633583-67718a00-d0df-11ea-9593-46135ca300c1.png)

- After:

![BrokenSubheaderUIMobile_After](https://user-images.githubusercontent.com/24670327/88633512-4f9a0600-d0df-11ea-97a1-59eb22457ad8.png)
