### PR TITLE
OpenPaaS-Suite/esn-frontend-inbox#122 moved the mailto-handler dependency outide of calendar.libs

### DIFF
--- a/src/esn.calendar.libs/app/app.module.js
+++ b/src/esn.calendar.libs/app/app.module.js
@@ -3,7 +3,6 @@
 angular.module('esn.calendar.libs', [
   'AngularJstz',
   'angularMoment',
-  'esn.mailto-handler',
   'esn.aggregator',
   'esn.authentication',
   'esn.avatar',

--- a/src/linagora.esn.calendar/app/app.js
+++ b/src/linagora.esn.calendar/app/app.js
@@ -102,7 +102,7 @@ require('esn-frontend-common-libs/src/frontend/js/modules/onscroll/on-scroll.mod
 require('esn-frontend-common-libs/src/frontend/js/modules/localstorage.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/scroll.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/previous-page.js');
-
+require('esn-frontend-mailto-handler/src/index.js');
 require('../../esn.calendar.libs/app/app.module.js');
 
 require('./app.config.js');


### PR DESCRIPTION
calendar.libs will be used with `esn-frontend-libs` so it has no use for mailto-handler

resolves https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/122