### PR TITLE
esn-dav-import-client#5: Adjusted the way ESNDavImportClient is constructed to use only a single instance of Client

### DIFF
--- a/src/linagora.esn.calendar/app/app.js
+++ b/src/linagora.esn.calendar/app/app.js
@@ -56,7 +56,8 @@ angular.module('esn.calendar', [
   'angular-clockpicker',
   'linagora.esn.videoconference',
   'linagora.esn.videoconference.calendar',
-  'esn.calendar.libs'
+  'esn.calendar.libs',
+  'esn.api-client'
 ]);
 
 require('esn-frontend-common-libs/src/frontend/js/modules/esn.router.js');
@@ -102,6 +103,7 @@ require('esn-frontend-common-libs/src/frontend/js/modules/onscroll/on-scroll.mod
 require('esn-frontend-common-libs/src/frontend/js/modules/localstorage.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/scroll.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/previous-page.js');
+require('esn-frontend-common-libs/src/frontend/js/modules/esn.api-client.js');
 require('esn-frontend-mailto-handler/src/index.js');
 require('../../esn.calendar.libs/app/app.module.js');
 

--- a/src/linagora.esn.calendar/app/settings/import/calendar-import.controller.js
+++ b/src/linagora.esn.calendar/app/settings/import/calendar-import.controller.js
@@ -12,7 +12,8 @@ function CalCalendarImportController(
   calendarService,
   calendarHomeService,
   calUIAuthorizationService,
-  session
+  session,
+  esnApiClient
 ) {
   var self = this;
 
@@ -50,8 +51,7 @@ function CalCalendarImportController(
   }
 
   function importFromFile() {
-    const OPENPAAS_URL = window.location.origin;
-    const esnDavImportClient = new ESNDavImportClient(fileUploadService.uploadFile, OPENPAAS_URL);
+    const esnDavImportClient = new ESNDavImportClient({ esnApiClient, uploadFile: fileUploadService.uploadFile });
 
     return esnDavImportClient.importFromFile(self.file, self.calendar.href);
   }


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-dav-import-client/issues/5. Please also refer to https://github.com/OpenPaaS-Suite/esn-dav-import-client/pull/6.