### PR TITLE
#155 The Attendees and Resources fields now follow the date/time field

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.pug
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.pug
@@ -50,18 +50,6 @@ form.event-form(role="form", name="form", aria-hidden="true", ng-class="{ 'reado
                         md-option(ng-value="calendar.getUniqueId()" ng-repeat="calendar in calendars | filter: (isNew(editedEvent) || canModifyEvent) ? { readOnly: false } : {}")
                           cal-select-calendar-item(calendar="calendar")
             cal-event-date-edition(event="editedEvent", disabled='!canModifyEvent', use-24hour-format='use24hourFormat', on-date-change='onDateChange')
-            .col-xs-12
-              .form-group(ng-show="canModifyEvent || editedEvent.location")
-                .input-group
-                  span.input-group-addon
-                    i.mdi.mdi-map-marker
-                  .fg-line
-                    input.input.location.form-control(type="text", ng-model='editedEvent.location', ng-model-options="{getterSetter: true, debounce: 500}", maxlength="{{::CAL_EVENT_FORM.location.maxlength}}", placeholder="{{ 'Location' | translate }}", ng-readonly="!canModifyEvent")
-
-            .col-xs-12
-              calendar-videoconference-form(event="editedEvent", can-modify-event="canModifyEvent")
-
-            .col-xs-12(dynamic-directive='calendar-map')
             cal-entities-autocomplete-input.cal-user-autocomplete-input(
               exclude-current-user='excludeCurrentUserFromSuggestedAttendees',
               ng-hide='!canModifyEventAttendees',
@@ -87,6 +75,16 @@ form.event-form(role="form", name="form", aria-hidden="true", ng-class="{ 'reado
               exclude-unknown-users='true',
               template='/calendar/app/components/entities-autocomplete-input/entities-autocomplete-input-freebusy-tag.html'
             )
+            .col-xs-12
+              .form-group(ng-show="canModifyEvent || editedEvent.location")
+                .input-group
+                  span.input-group-addon
+                    i.mdi.mdi-map-marker
+                  .fg-line
+                    input.input.location.form-control(type="text", ng-model='editedEvent.location', ng-model-options="{getterSetter: true, debounce: 500}", maxlength="{{::CAL_EVENT_FORM.location.maxlength}}", placeholder="{{ 'Location' | translate }}", ng-readonly="!canModifyEvent")
+            .col-xs-12
+              calendar-videoconference-form(event="editedEvent", can-modify-event="canModifyEvent")
+            .col-xs-12(dynamic-directive='calendar-map')
             .col-xs-12
               cal-attendee-tabs(
                 ng-show="selectedTab && attendees.users.length > 0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6764881/94908378-7ab32400-0499-11eb-8858-dfe6252b3ba9.png)
