### PR TITLE
#89 allow event organizer to update the event participation status without saving the form

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
@@ -288,6 +288,29 @@ function CalEventFormController(
     });
   }
 
+  function _changeOrganizerParticipation(status) {
+    const eventPayload = $scope.event.clone();
+
+    eventPayload.setOrganizerPartStat(status);
+
+    calEventService.changeParticipation(eventPayload.path, eventPayload, [eventPayload.organizer.email], status, eventPayload.etag)
+      .then(({ etag }) => {
+        if (!etag) {
+          return notificationFactory.weakError('', 'Event participation modification failed');
+        }
+
+        calPartstatUpdateNotificationService(status);
+
+        // Set the new Etag to avoid 412 precondition failed
+        $scope.event.etag = etag;
+        $scope.editedEvent.etag = etag;
+      })
+      .catch(err => {
+        $log.error('Organizer event participation update failed', err);
+        notificationFactory.weakError('Event participation modification failed', 'Please refresh your calendar');
+      });
+  }
+
   function _changeParticipationAsAttendee(event) {
     var partstat = $scope.calendarOwnerAsAttendee.partstat;
 
@@ -394,6 +417,7 @@ function CalEventFormController(
       if (status !== $scope.editedEvent.getOrganizerPartStat()) {
         $scope.editedEvent.setOrganizerPartStat(status);
         $scope.$broadcast(CAL_EVENTS.EVENT_ATTENDEES_UPDATE);
+        _changeOrganizerParticipation(status);
       }
     } else if ($scope.editedEvent.isInstance()) {
       $modal({

--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
@@ -292,6 +292,7 @@ function CalEventFormController(
     const eventPayload = $scope.event.clone();
 
     eventPayload.setOrganizerPartStat(status);
+    $scope.restActive = true;
 
     calEventService.changeParticipation(eventPayload.path, eventPayload, [eventPayload.organizer.email], status, eventPayload.etag)
       .then(({ etag }) => {
@@ -308,6 +309,9 @@ function CalEventFormController(
       .catch(err => {
         $log.error('Organizer event participation update failed', err);
         notificationFactory.weakError('Event participation modification failed', 'Please refresh your calendar');
+      })
+      .finally(() => {
+        $scope.restActive = false;
       });
   }
 

--- a/src/esn.calendar.libs/app/services/event-service.js
+++ b/src/esn.calendar.libs/app/services/event-service.js
@@ -497,7 +497,10 @@ function calEventService(
     if (!angular.isArray(event.attendees)) {
       return $q.when(null);
     }
-    if (!event.changeParticipation(status, emails)) {
+
+    if (event.organizer && emails.length === 1 && emails[0] === event.organizer.email) {
+      event.setOrganizerPartStat(status);
+    } else if (!event.changeParticipation(status, emails)) {
       return $q.when(null);
     }
 

--- a/src/esn.calendar.libs/app/services/event-service.spec.js
+++ b/src/esn.calendar.libs/app/services/event-service.spec.js
@@ -1430,6 +1430,37 @@ describe('The calEventService service', function() {
       expect(errorSpy).to.have.been.calledOnce;
     });
 
+    it('should call the event setOrganizerPartStat function when the organizer is trying to change his status', function() {
+      const emails = ['organize@example.com'];
+      const promiseSpy = sinon.spy();
+
+      self.calEventAPI.changeParticipation = sinon.stub().returns($q.when({}));
+      self.event.setOrganizerPartStat = sinon.spy();
+      self.event.changeParticipation = sinon.spy();
+      self.event.organizer = { email: 'organize@example.com' };
+      self.calEventService.changeParticipation('/path/to/uid.ics', self.event, emails, 'DECLINED').then(promiseSpy);
+      self.$rootScope.$apply();
+
+      expect(self.event.setOrganizerPartStat).to.have.been.called;
+      expect(self.event.changeParticipation).to.not.have.been.called;
+      expect(self.calEventAPI.changeParticipation).to.have.been.called;
+    });
+
+    it('should not call the event setOrganizerPartStat function when a non organizer is trying to change his status', function() {
+      const emails = ['somethingelse@example.com'];
+      const promiseSpy = sinon.spy();
+
+      self.calEventAPI.changeParticipation = sinon.stub().returns($q.when({}));
+      self.event.setOrganizerPartStat = sinon.spy();
+      self.event.changeParticipation = sinon.spy();
+      self.event.organizer = { email: 'organize@example.com' };
+      self.calEventService.changeParticipation('/path/to/uid.ics', self.event, emails, 'DECLINED').then(promiseSpy);
+      self.$rootScope.$apply();
+
+      expect(self.event.setOrganizerPartStat).to.not.have.been.called;
+      expect(self.event.changeParticipation).to.have.been.called;
+    });
+
     // Everything else is covered by the modify fn
   });
 


### PR DESCRIPTION
**DEMOS**:

edit the organizer participation without saving the form: https://streamable.com/rq9hal
edit the organizer participation  and continue editing and saving the form: https://streamable.com/2n9wpy
edit organizer participation with recurrent events: https://streamable.com/upxz50
disable action forms while updating the partstat: https://streamable.com/l88g6l