### PR TITLE
Revert "#140 Make dialog box draggable"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "esn-frontend-mailto-handler": "github:openpaas-suite/esn-frontend-mailto-handler#main",
     "esn-frontend-videoconference-calendar": "github:openpaas-suite/esn-frontend-videoconference-calendar#main",
     "esn-frontend-group": "github:openpaas-suite/esn-frontend-group#main",
-    "fullcalendar": "3.9.0",
-    "jquery-ui": "1.12.1"
+    "fullcalendar": "3.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",

--- a/src/esn.calendar.libs/app/components/event/form/event-form.directive.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.directive.js
@@ -18,11 +18,7 @@ function calEventForm() {
 
   ////////////
 
-  function link(scope, element) {
-    element.children().draggable({
-      handle: '.modal-header, .modal-body, .modal-footer'
-    });
-
+  function link(scope) {
     scope.$on('$locationChangeStart', hideModal);
 
     function hideModal(event) {

--- a/src/esn.calendar.libs/app/components/event/form/event-form.directive.spec.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.directive.spec.js
@@ -76,10 +76,4 @@ describe('The cal-event-form Angular module directives', function() {
 
     expect(event.defaultPrevented).to.be.false;
   });
-
-  it('.modal-dialog should have class ui-draggable', function() {
-    var element = this.initDirective(this.$scope);
-
-    expect(element.children().hasClass('ui-draggable')).to.be.true;
-  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-require('jquery-ui/ui/widgets/draggable.js');
 require('fullcalendar/dist/fullcalendar.js');
 require('fullcalendar/dist/locale-all.js');
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,6 @@
 window.jstz = require('esn-frontend-common-libs/src/frontend/components/jstzdetect/jstz.js');
 window.jQuery = require('jquery/dist/jquery.js');
 window.$ = window.jQuery;
-require('jquery-ui/ui/widgets/draggable.js');
 require('esn-frontend-common-libs/src/frontend/vendor-libs.js');
 require('esn-frontend-common-libs/src/frontend/js/material.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/session.js');


### PR DESCRIPTION
Reverts OpenPaaS-Suite/esn-frontend-calendar#151.

Reasons:

- The modal body is also draggable, which causes issues with the dropdowns inside the body. For example, you cannot select the options from the autocomplete dropdowns ("Attendees", "Resources", etc.).
- It breaks the event dialog completely in mobile devices.