### PR TITLE
esn-frontend-calendar#188: Now the resource autocomplete dropdown is no longer overlapped by the fields below

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.less
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.less
@@ -55,6 +55,12 @@ body  {
 
     .cal-user-autocomplete-input {
       tags-input {
+        z-index: 4;
+      }
+    }
+
+    .cal-resource-autocomplete-input {
+      tags-input {
         z-index: 3;
       }
     }

--- a/src/esn.calendar.libs/app/components/event/form/event-form.pug
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.pug
@@ -62,7 +62,7 @@ form.event-form(role="form", name="form", aria-hidden="true", ng-class="{ 'reado
               on-entity-added='onUserAttendeesAdded',
               template='/calendar/app/components/entities-autocomplete-input/entities-autocomplete-input-freebusy-tag.html'
             )
-            cal-entities-autocomplete-input(
+            cal-entities-autocomplete-input.cal-resource-autocomplete-input(
               ng-hide='!canModifyEventAttendees',
               types='[CAL_ATTENDEE_OBJECT_TYPE.resource]',
               input-type="text"


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/188.

Demo:

![image](https://user-images.githubusercontent.com/24670327/95430170-91fc8080-0975-11eb-8a80-7d1e1ccaf355.png)
