### PR TITLE
#98 close the time selector when the user switches between inputs with tab

### DIFF
--- a/src/esn.calendar.libs/app/components/time-select/time-select.controller.js
+++ b/src/esn.calendar.libs/app/components/time-select/time-select.controller.js
@@ -29,6 +29,7 @@ function calTimeSelectController($scope, $element, calMoment) {
   }
 
   function onInputKeydown(event, mdMenu) {
+    if (event.key === 'Tab') return mdMenu.close();
     if (event.key !== 'Enter') return;
 
     event.preventDefault();

--- a/src/esn.calendar.libs/app/components/time-select/time-select.controller.spec.js
+++ b/src/esn.calendar.libs/app/components/time-select/time-select.controller.spec.js
@@ -277,5 +277,28 @@ describe('the calTimeSelectController', function() {
       expect(menu.close).to.not.have.been.called;
       expect(ctrl.onTimeSelectBlur).to.not.have.been.called;
     });
+
+    it('should close the mdMenu when the user presses Tab', function() {
+      const ctrl = initCtrl(
+        {
+          timeFormat: 'H:mm',
+          locale: 'fr',
+          onTimeChange: () => { }
+        }
+      );
+      const event = {
+        key: 'Tab',
+        preventDefault: () => { }
+      };
+      const menu = {
+        close: sinon.spy()
+      };
+
+      ctrl.onTimeSelectBlur = sinon.spy();
+
+      ctrl.onInputKeydown(event, menu);
+      expect(menu.close).to.have.been.called;
+      expect(ctrl.onTimeSelectBlur).to.not.have.been.called;
+    });
   });
 });

--- a/src/esn.calendar.libs/app/components/time-select/time-select.pug
+++ b/src/esn.calendar.libs/app/components/time-select/time-select.pug
@@ -5,6 +5,7 @@ md-menu(md-offset="10 60")
       type="text",
       size="10",
       ng-click="$mdMenu.open()",
+      ng-focus="$mdMenu.open()",
       ng-change="ctrl.onTimeInputChange()",
       ng-blur="ctrl.onTimeSelectBlur()",
       ng-keydown="ctrl.onInputKeydown($event, $mdMenu)",


### PR DESCRIPTION
demo: https://streamable.com/sm7cv1

updated demo: https://streamable.com/43f4u5

Continues to resolve https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/98.