### PR TITLE
esn-frontend-calendar#168: Now the notifcation when saving an event will be closed when there is an error while saving the event

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
@@ -260,8 +260,6 @@ function CalEventFormController(
       $scope.restActive = true;
       _hideModal();
 
-      const notification = _displayNotification(notificationFactory.strongInfo, 'Event creation', 'Saving event...');
-
       $scope.editedEvent.attendees = getAttendees();
       setOrganizer()
         .then(cacheAttendees)
@@ -272,11 +270,7 @@ function CalEventFormController(
             notifyFullcalendar: $state.is('calendar.main')
           });
         })
-        .then(success => {
-          notification.close();
-
-          return onEventCreateUpdateResponse(success);
-        })
+        .then(onEventCreateUpdateResponse)
         .finally(function() {
           $scope.restActive = false;
         });
@@ -289,10 +283,7 @@ function CalEventFormController(
     $scope.restActive = true;
     _hideModal();
 
-    const notification = _displayNotification(notificationFactory.strongInfo, 'Event deletion', 'Removing event...');
-
     calEventService.removeEvent($scope.event.path, $scope.event, $scope.event.etag).finally(function() {
-      notification.close();
       $scope.restActive = false;
     });
   }
@@ -343,8 +334,6 @@ function CalEventFormController(
       $scope.editedEvent.alarm = $scope.event.alarm;
     }
 
-    const notification = _displayNotification(notificationFactory.strongInfo, 'Event update', 'Saving event...');
-
     return $q.when()
       .then(cacheAttendees)
       .then(denormalizeAttendees)
@@ -358,11 +347,7 @@ function CalEventFormController(
           { graceperiod: true, notifyFullcalendar: $state.is('calendar.main') }
         );
       })
-      .then(success => {
-        notification.close();
-
-        return onEventCreateUpdateResponse(success);
-      })
+      .then(onEventCreateUpdateResponse)
       .finally(function() {
         $scope.restActive = false;
       });

--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.spec.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.spec.js
@@ -858,56 +858,6 @@ describe('The CalEventFormController controller', function() {
           });
         });
 
-        it('should send modify request and display a notification while the request is being processed and close it when the request is done', function() {
-          scope.event = CalendarShell.fromIncompleteShell({
-            start: moment(),
-            end: moment(),
-            title: 'title',
-            attendees: [{
-              name: 'attendee1',
-              email: 'attendee1@openpaas.org',
-              partstart: 'DECLINED'
-            }]
-          });
-          initController();
-
-          scope.attendees.users = [{
-            name: 'attendee1',
-            email: 'attendee1@openpaas.org',
-            partstat: 'ACCEPTED'
-          }];
-          scope.editedEvent = CalendarShell.fromIncompleteShell({
-            start: moment(),
-            end: moment(),
-            title: 'title',
-            attendees: scope.attendees.users
-          });
-
-          const deferred = $q.defer();
-
-          calEventServiceMock.modifyEvent = sinon.stub().returns(deferred.promise);
-
-          scope.modifyEvent();
-
-          scope.$digest();
-
-          const calendarId = calendarTest.id;
-          const expectedPath = '/calendars/' + calendarHomeId + '/' + calendarId;
-
-          expect(calEventServiceMock.modifyEvent).to.have.been.calledWith(expectedPath, scope.editedEvent, scope.event, scope.etag, sinon.match.any, {
-            graceperiod: true,
-            notifyFullcalendar: $stateMock.is()
-          });
-          expect(notificationFactoryMock.strongInfo).to.have.been.calledWith('Event update', 'Saving event...');
-          expect(closeNotificationStub).to.have.not.been.called;
-
-          deferred.resolve();
-
-          scope.$digest();
-
-          expect(closeNotificationStub).to.have.been.calledOnce;
-        });
-
         it('should not send modify request if properties not visible in the UI changed', function(done) {
           let editedEvent = {};
 
@@ -1441,27 +1391,6 @@ describe('The CalEventFormController controller', function() {
         expect(resourcesCacheSpy).to.have.been.calledWith(newResources);
       });
 
-      it('should display a notification while the request to create event is being processed and close it when the request is done', function() {
-        const deferred = $q.defer();
-
-        calEventServiceMock.createEvent = sinon.stub().returns(deferred.promise);
-
-        scope.createEvent();
-        scope.$digest();
-
-        expect(calEventServiceMock.createEvent).to.have.been.calledWith(calendarTest, scope.editedEvent, {
-          graceperiod: true,
-          notifyFullcalendar: $stateMock.is()
-        });
-        expect(notificationFactoryMock.strongInfo).to.have.been.calledWith('Event creation', 'Saving event...');
-        expect(closeNotificationStub).to.have.not.been.called;
-
-        deferred.resolve();
-        scope.$digest();
-
-        expect(closeNotificationStub).to.have.been.calledOnce;
-      });
-
       it('should return error notification when there is no selected calendar', function() {
         scope.selectedCalendar = {};
 
@@ -1530,36 +1459,6 @@ describe('The CalEventFormController controller', function() {
         expect(calEventServiceMock.createEvent).to.have.been.calledOnce;
         expect(restoreSpy).to.not.have.been.called;
         expect(calOpenEventFormMock).to.have.been.calledWith(sinon.match.any, scope.editedEvent);
-      });
-    });
-
-    describe('deleteEvent function', function() {
-      beforeEach(function() {
-        scope.event = CalendarShell.fromIncompleteShell({
-          _id: '123456',
-          start: moment('2013-02-08 12:30'),
-          end: moment('2013-02-08 13:30'),
-          otherProperty: 'aString'
-        });
-        initController();
-      });
-
-      it('should display a notification while the request to delete event is being processed and close it when the request is done', function() {
-        const deferred = $q.defer();
-
-        calEventServiceMock.removeEvent = sinon.stub().returns(deferred.promise);
-
-        scope.deleteEvent();
-        scope.$digest();
-
-        expect(calEventServiceMock.removeEvent).to.have.been.calledWith(scope.event.path, scope.event, scope.event.etag);
-        expect(notificationFactoryMock.strongInfo).to.have.been.calledWith('Event deletion', 'Removing event...');
-        expect(closeNotificationStub).to.have.not.been.called;
-
-        deferred.resolve();
-        scope.$digest();
-
-        expect(closeNotificationStub).to.have.been.calledOnce;
       });
     });
 

--- a/src/esn.calendar.libs/app/services/event-service.js
+++ b/src/esn.calendar.libs/app/services/event-service.js
@@ -447,7 +447,7 @@ function calEventService(
           cancelTooLate: 'It is too late to cancel the modification',
           cancelSuccess: esnI18nService.translate('Calendar - Modification of %s has been canceled.', { title: calEventUtils.getEventTitle(event) }),
           gracePeriodFail: {
-            text: 'Event modification failed, please refresh your calendar',
+            text: 'Event modification failed. Please refresh your calendar',
             delay: -1,
             hideCross: true,
             actionText: 'Refresh calendar',

--- a/src/esn.calendar.libs/app/services/event-service.js
+++ b/src/esn.calendar.libs/app/services/event-service.js
@@ -223,6 +223,8 @@ function calEventService(
       return false;
     }
 
+    const savingEventNotification = notificationFactory.strongInfo('Event creation', 'Saving event...');
+
     return calEventAPI.create(eventPath, event.vcalendar, options)
       .then(function(response) {
         if (!CAL_GRACE_DELAY_IS_ACTIVE || typeof response !== 'string') {
@@ -256,6 +258,8 @@ function calEventService(
         return response;
       })
       .finally(function() {
+        savingEventNotification.close();
+
         event.gracePeriodTaskId = undefined;
       });
   }
@@ -293,6 +297,8 @@ function calEventService(
     }
 
     function performRemove() {
+      const removingEventNotification = notificationFactory.strongInfo('Event removal', 'Removing event...');
+
       return calEventAPI.remove(eventPath, etag)
         .then(function(id) {
           if (!CAL_GRACE_DELAY_IS_ACTIVE) {
@@ -340,6 +346,8 @@ function calEventService(
           return CAL_GRACE_DELAY_IS_ACTIVE ? response : true;
         })
         .finally(function() {
+          removingEventNotification.close();
+
           event.gracePeriodTaskId = undefined;
         });
     }
@@ -414,6 +422,8 @@ function calEventService(
       calendarEventEmitter.emitModifiedEvent(oldEvent);
     }
 
+    const savingEventNotification = notificationFactory.strongInfo('Event modification', 'Saving event...');
+
     return event.getModifiedMaster().then(function(masterEvent) {
       return calEventAPI.modify(path, masterEvent.vcalendar, etag);
     })
@@ -463,6 +473,8 @@ function calEventService(
         return CAL_GRACE_DELAY_IS_ACTIVE ? response : true;
       })
       .finally(function() {
+        savingEventNotification.close();
+
         delete oldEventStore[event.uid];
         event.gracePeriodTaskId = undefined;
       });

--- a/src/esn.calendar.libs/app/services/event-service.spec.js
+++ b/src/esn.calendar.libs/app/services/event-service.spec.js
@@ -46,10 +46,13 @@ describe('The calEventService service', function() {
       }
     };
 
+    self.closeNotificationMock = sinon.stub();
+
     self.notificationFactoryMock = {
       weakInfo: sinon.spy(),
       weakError: sinon.spy(),
-      weakSuccess: sinon.spy()
+      weakSuccess: sinon.spy(),
+      strongInfo: sinon.stub().returns({ close: self.closeNotificationMock })
     };
 
     self.jstz = {
@@ -1560,6 +1563,67 @@ describe('The calEventService service', function() {
         self.$httpBackend.expectPUT(getEventPath()).respond(201, { id: '123456789' });
       });
 
+      it('should display a notification when the request to create an event is being processed and close it when the request succeeds', function(done) {
+        const vcalendar = new ICAL.Component('vcalendar');
+        const vevent = new ICAL.Component('vevent');
+
+        vevent.addPropertyWithValue('uid', eventUUID);
+        vevent.addPropertyWithValue('dtstart', dtstart);
+        vevent.addPropertyWithValue('dtend', dtend);
+        vevent.addPropertyWithValue('summary', 'test event');
+        vcalendar.addSubcomponent(vevent);
+
+        const path = getEventPath();
+        const etag = 'ETAG';
+        const calendarShell = new self.CalendarShell(vcalendar, {
+          path: path,
+          etag: etag
+        });
+
+        self.calEventAPI.create = () => $q.resolve();
+
+        self.calEventService.createEvent(calendar, calendarShell)
+          .then(() => {
+            expect(self.closeNotificationMock).to.have.been.calledOnce;
+            done();
+          })
+          .catch(err => done(err || new Error('should resolve')));
+
+        expect(self.notificationFactoryMock.strongInfo).to.have.been.calledWith('Event creation', 'Saving event...');
+        self.$rootScope.$digest();
+      });
+
+      it('should display a notification when the request to create an event is being processed and close it when the request fails', function(done) {
+        const vcalendar = new ICAL.Component('vcalendar');
+        const vevent = new ICAL.Component('vevent');
+
+        vevent.addPropertyWithValue('uid', eventUUID);
+        vevent.addPropertyWithValue('dtstart', dtstart);
+        vevent.addPropertyWithValue('dtend', dtend);
+        vevent.addPropertyWithValue('summary', 'test event');
+        vcalendar.addSubcomponent(vevent);
+
+        const path = getEventPath();
+        const etag = 'ETAG';
+        const calendarShell = new self.CalendarShell(vcalendar, {
+          path: path,
+          etag: etag
+        });
+
+        self.calEventAPI.create = () => $q.reject(new Error('Request failed'));
+
+        self.calEventService.createEvent(calendar, calendarShell)
+          .then(() => done(new Error('should not resolve')))
+          .catch(err => {
+            expect(err).to.exist;
+            expect(self.closeNotificationMock).to.have.been.calledOnce;
+            done();
+          });
+
+        expect(self.notificationFactoryMock.strongInfo).to.have.been.calledWith('Event creation', 'Saving event...');
+        self.$rootScope.$digest();
+      });
+
       it('should not call calCachedEventSource.registerAdd', function() {
         self.calEventService.createEvent(calendar, event, {});
 
@@ -1618,6 +1682,35 @@ describe('The calEventService service', function() {
         self.$httpBackend.expectDELETE('/dav/api/path/to/00000000-0000-4000-a000-000000000000.ics').respond(204, { id: '123456789' });
       });
 
+      it('should display a notification when the request to remove the event is being processed and close it when the request succeeds', function(done) {
+        self.calEventAPI.remove = () => $q.resolve();
+
+        self.calEventService.removeEvent('/path/to/00000000-0000-4000-a000-000000000000.ics', event, 'etag')
+          .then(() => {
+            expect(self.closeNotificationMock).to.have.been.calledOnce;
+            done();
+          })
+          .catch(err => done(err || new Error('should resolve')));
+
+        expect(self.notificationFactoryMock.strongInfo).to.have.been.calledWith('Event removal', 'Removing event...');
+        self.$rootScope.$digest();
+      });
+
+      it('should display a notification when the request to remove the event is being processed and close it when the request fails', function(done) {
+        self.calEventAPI.remove = () => $q.reject(new Error('Request failed'));
+
+        self.calEventService.removeEvent('/path/to/00000000-0000-4000-a000-000000000000.ics', event, 'etag')
+          .then(() => done(new Error('should not resolve')))
+          .catch(err => {
+            expect(err).to.exist;
+            expect(self.closeNotificationMock).to.have.been.calledOnce;
+            done();
+          });
+
+        expect(self.notificationFactoryMock.strongInfo).to.have.been.calledWith('Event removal', 'Removing event...');
+        self.$rootScope.$digest();
+      });
+
       it('should not call calCachedEventSource.registerDelete', function() {
         self.calEventService.removeEvent('/path/to/00000000-0000-4000-a000-000000000000.ics', event, 'etag');
 
@@ -1659,6 +1752,7 @@ describe('The calEventService service', function() {
           { emails: ['user1@lng.com'], partstat: 'ACCEPTED' },
           { emails: ['user2@lng.com'], partstat: 'NEEDS-ACTION' }
         ];
+
         var vcalendar = new ICAL.Component('vcalendar');
         var vevent = new ICAL.Component('vevent');
 
@@ -1687,6 +1781,35 @@ describe('The calEventService service', function() {
         sinon.spy(self.gracePeriodService, 'grace');
 
         self.$httpBackend.expectPUT('/dav/api/path/to/uid.ics').respond(204, { id: '123456789' });
+      });
+
+      it('should display a notification while the request to modify the event is being processed and close it when the request succeeds', function(done) {
+        self.calEventAPI.modify = () => $q.when();
+
+        self.calEventService.modifyEvent('/path/to/uid.ics', event, event, 'etag', angular.noop)
+          .then(() => {
+            expect(self.closeNotificationMock).to.have.been.calledOnce;
+            done();
+          })
+          .catch(err => done(err || new Error('should resolve')));
+
+        expect(self.notificationFactoryMock.strongInfo).to.have.been.calledWith('Event modification', 'Saving event...');
+        self.$rootScope.$digest();
+      });
+
+      it('should display a notification while the request to modify the event is being processed and close it when the request fails', function(done) {
+        self.calEventAPI.modify = () => $q.reject(new Error('Request failed'));
+
+        self.calEventService.modifyEvent('/path/to/uid.ics', event, event, 'etag', angular.noop)
+          .then(() => done(new Error('should not resolve')))
+          .catch(err => {
+            expect(err).to.exist;
+            expect(self.closeNotificationMock).to.have.been.calledOnce;
+            done();
+          });
+
+        expect(self.notificationFactoryMock.strongInfo).to.have.been.calledWith('Event modification', 'Saving event...');
+        self.$rootScope.$digest();
       });
 
       it('should not call calendarEventEmitterMock.emitModifiedEvent', function() {

--- a/src/esn.calendar.libs/app/services/event-service.spec.js
+++ b/src/esn.calendar.libs/app/services/event-service.spec.js
@@ -702,7 +702,7 @@ describe('The calEventService service', function() {
       self.$httpBackend.flush();
       expect(self.gracePeriodService.grace).to.have.been.calledWith(sinon.match({
         gracePeriodFail: {
-          text: 'Event modification failed, please refresh your calendar',
+          text: 'Event modification failed. Please refresh your calendar',
           actionText: 'Refresh calendar',
           delay: -1,
           hideCross: true,

--- a/src/esn.calendar.libs/i18n/en.json
+++ b/src/esn.calendar.libs/i18n/en.json
@@ -107,7 +107,7 @@
   "Event deletion failed. Please refresh your calendar": "Event deletion failed. Please refresh your calendar",
   "Event details": "Event details",
   "Event modification failed": "Event modification failed",
-  "Event modification failed, please refresh your calendar": "Event modification failed, please refresh your calendar",
+  "Event modification failed. Please refresh your calendar": "Event modification failed. Please refresh your calendar",
   "Event participation modification failed": "Event participation modification failed",
   "Event removed": "Event removed",
   "Event updated": "Event updated",

--- a/src/esn.calendar.libs/i18n/fr.json
+++ b/src/esn.calendar.libs/i18n/fr.json
@@ -107,7 +107,7 @@
   "Event deletion failed. Please refresh your calendar": "La suppression de l'événement a échoué. Veuillez actualiser votre calendrier",
   "Event details": "Détails de l'événement",
   "Event modification failed": "La modification de l'événement a échouée ",
-  "Event modification failed, please refresh your calendar": "La modification de l'événement a échouée, actualisez votre calendrier",
+  "Event modification failed. Please refresh your calendar": "La modification de l'événement a échouée. Veuillez actualiser votre calendrier",
   "Event participation modification failed": "La modification de la participation à l'événement a échouée",
   "Event removed": "Événement supprimé",
   "Event updated": "Événement mis à jour",

--- a/src/esn.calendar.libs/i18n/ru.json
+++ b/src/esn.calendar.libs/i18n/ru.json
@@ -107,7 +107,7 @@
   "Event deletion failed. Please refresh your calendar": "Ошибка удаления события. Пожалуйста, обновите свой календарь",
   "Event details": "Детали события",
   "Event modification failed": "Ошибка модификации события",
-  "Event modification failed, please refresh your calendar": "Не удалось изменить событие, обновите календарь",
+  "Event modification failed. Please refresh your calendar": "Не удалось изменить событие. обновите календарь",
   "Event participation modification failed": "Не удалось изменить участие в мероприятии",
   "Event removed": "Событие удалено",
   "Event updated": "Событие обновлено",

--- a/src/esn.calendar.libs/i18n/vi.json
+++ b/src/esn.calendar.libs/i18n/vi.json
@@ -107,7 +107,7 @@
   "Event deletion failed. Please refresh your calendar": "Xóa sự kiện thất bại. Vui lòng tải lại lịch biểu",
   "Event details": "Chi tiết sự kiện",
   "Event modification failed": "Chỉnh sửa sự kiện thất bại ",
-  "Event modification failed, please refresh your calendar": "Chỉnh sửa sự kiện thất bại, vui lòng tải lại lịch biểu",
+  "Event modification failed. Please refresh your calendar": "Chỉnh sửa sự kiện thất bại. Vui lòng tải lại lịch biểu",
   "Event participation modification failed": "Thay đổi danh sách người tham dự thất bại",
   "Event removed": "Đã xóa sự kiện",
   "Event updated": "Đã cập nhật sự kiện",

--- a/src/esn.calendar.libs/i18n/zh.json
+++ b/src/esn.calendar.libs/i18n/zh.json
@@ -107,7 +107,7 @@
   "Event deletion failed. Please refresh your calendar": "删除事件失败。请刷新日历",
   "Event details": "事件详细信息",
   "Event modification failed": "修改事件失败",
-  "Event modification failed, please refresh your calendar": "修改事件失败。请刷新日历",
+  "Event modification failed. Please refresh your calendar": "修改事件失败。请刷新日历",
   "Event participation modification failed": "修改事件参与失败",
   "Event removed": "事件被移除",
   "Event updated": "事件更新完成",


### PR DESCRIPTION
Continues to resolve https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/168.

- Demo:

[![Demo-Event-Update-Notification](https://user-images.githubusercontent.com/24670327/96209281-6a22a380-0f99-11eb-89ca-6fc80510db6e.gif)](https://streamable.com/5xzep7)