### PR TITLE
 #216 redirect internal user to event detail when he change participation from link in email invitation

### DIFF
--- a/src/esn.calendar.libs/app/services/event-service.js
+++ b/src/esn.calendar.libs/app/services/event-service.js
@@ -41,12 +41,14 @@ function calEventService(
   CAL_GRACE_DELAY,
   CAL_GRACE_DELAY_IS_ACTIVE,
   CAL_EVENTS,
-  session
+  session,
+  httpConfigurer
 ) {
   var self = this;
   var oldEventStore = {};
 
   self.changeParticipation = changeParticipation;
+  self.changeParticipationFromLink = changeParticipationFromLink;
   self.sendCounter = sendCounter;
   self.getInvitedAttendees = getInvitedAttendees;
   self.getEvent = getEvent;
@@ -536,6 +538,18 @@ function calEventService(
   }
 
   /**
+   * Change the status of participation from external link
+   * @return {Mixed}                              Jwt
+   * Note that we retry the request in case of 412. This is the code returned for a conflict.
+   */
+  function changeParticipationFromLink(jwt) {
+
+    return $http({ method: 'GET', url: getChangeParticipationUrl(jwt) })
+      .then(response => response.data)
+      .catch(error => error.data);
+  }
+
+  /**
    * Answers to an invite with a counter proposal (suggesting another time)
    * @param  {CalendarShell}            suggestedEvent      the event in which we seek the attendees
    * See https://tools.ietf.org/html/rfc5546#page-86
@@ -575,4 +589,8 @@ function calEventService(
       return new CalendarShell(ICAL.Component.fromString(response.data));
     });
   }
+  function getChangeParticipationUrl(jwt) {
+    return `${httpConfigurer.getUrl('/calendar/api/calendars/event/participation')}?jwt=${jwt}`;
+  }
+
 }

--- a/src/esn.calendar.libs/app/services/event-service.js
+++ b/src/esn.calendar.libs/app/services/event-service.js
@@ -546,15 +546,13 @@ function calEventService(
    * @param {Mixed}    jwt        jwt
    */
   function changeParticipationFromLink(eventUid, jwt) {
-    $http({ method: 'GET', url: getChangeParticipationUrl(jwt) })
+    return $http({ method: 'GET', url: getChangeParticipationUrl(jwt) })
       .then(() => calendarHomeService.getUserCalendarHomeId())
-      .then(calendarHomeId => {
-        getEventByUID(calendarHomeId, eventUid).then(event => {
-          calOpenEventForm(calendarHomeId, event);
-        });
-      }).catch(err => {
-        $log.error('Can not change participation', err);
-        notificationFactory.weakError(null, 'Event participation modification failed');
+      .then(calendarHomeId => getEventByUID(calendarHomeId, eventUid))
+      .then(event => calOpenEventForm(null, event))
+      .catch(err => {
+        $log.error('Can not display the requested event', err);
+        notificationFactory.weakError('Can not display the event');
       });
   }
 

--- a/src/esn.calendar.libs/app/services/event-service.spec.js
+++ b/src/esn.calendar.libs/app/services/event-service.spec.js
@@ -1508,7 +1508,7 @@ describe('The calEventService service', function() {
         const stubArgs = calOpenEventFormMock.firstCall.args;
 
         expect(calendarHomeServiceMock.getUserCalendarHomeId).to.have.been.called;
-        expect(stubArgs[0]).to.eq(1);
+        expect(calOpenEventFormMock).to.have.been.called;
         expect(stubArgs[1].etag).to.eq('"123123"');
       });
     });

--- a/src/linagora.esn.calendar/app/routes.js
+++ b/src/linagora.esn.calendar/app/routes.js
@@ -32,6 +32,26 @@ function routesConfig($stateProvider) {
         }
       }
     })
+    .state('calendar.main.participation', {
+      url: '/participation',
+
+      onEnter: function($log, session, $state, notificationFactory, calendarHomeService, $location, calOpenEventForm, calEventService) {
+        const jwt = $location.search().jwt;
+        const eventUid = $location.search().eventUid;
+
+        if (jwt && eventUid) {
+          calEventService.changeParticipationFromLink(jwt).then(response => response)
+            .then(() => calendarHomeService.getUserCalendarHomeId())
+            .then(calendarHomeId => calEventService.getEventByUID(calendarHomeId, eventUid))
+            .then((event, calendarHomeId) => calOpenEventForm(calendarHomeId, event))
+            .catch(err => {
+              $log.error('Can not display the requested event', err);
+              notificationFactory.weakError('Can not display the event');
+              $state.go('calendar.main');
+            });
+        }
+      }
+    })
     .state('calendar.main.planning', {
       url: '/planning',
       views: {

--- a/src/linagora.esn.calendar/app/routes.js
+++ b/src/linagora.esn.calendar/app/routes.js
@@ -36,8 +36,7 @@ function routesConfig($stateProvider) {
       url: '/participation',
       resolve: {
         event: function($log, $state, $location, notificationFactory, calEventService) {
-          const jwt = $location.search().jwt;
-          const eventUid = $location.search().eventUid;
+          const { jwt, eventUid } = $location.search();
 
           if (jwt && eventUid) {
             calEventService.changeParticipationFromLink(eventUid, jwt)

--- a/src/linagora.esn.calendar/app/routes.js
+++ b/src/linagora.esn.calendar/app/routes.js
@@ -34,21 +34,19 @@ function routesConfig($stateProvider) {
     })
     .state('calendar.main.participation', {
       url: '/participation',
+      resolve: {
+        event: function($log, $state, $location, notificationFactory, calEventService) {
+          const jwt = $location.search().jwt;
+          const eventUid = $location.search().eventUid;
 
-      onEnter: function($log, session, $state, notificationFactory, calendarHomeService, $location, calOpenEventForm, calEventService) {
-        const jwt = $location.search().jwt;
-        const eventUid = $location.search().eventUid;
-
-        if (jwt && eventUid) {
-          calEventService.changeParticipationFromLink(jwt).then(response => response)
-            .then(() => calendarHomeService.getUserCalendarHomeId())
-            .then(calendarHomeId => calEventService.getEventByUID(calendarHomeId, eventUid))
-            .then((event, calendarHomeId) => calOpenEventForm(calendarHomeId, event))
-            .catch(err => {
-              $log.error('Can not display the requested event', err);
-              notificationFactory.weakError('Can not display the event');
-              $state.go('calendar.main');
-            });
+          if (jwt && eventUid) {
+            calEventService.changeParticipationFromLink(eventUid, jwt)
+              .catch(err => {
+                $log.error('Can not display the requested event', err);
+                notificationFactory.weakError(null, 'Can not display the event');
+                $state.go('calendar.main');
+              });
+          }
         }
       }
     })


### PR DESCRIPTION
**Demo**: https://streamable.com/aujioy
**Backend PR** :https://ci.linagora.com/linagora/lgs/openpaas/linagora.esn.calendar/merge_requests/686

**Flow Chart of invite user (internal and external)** 

![Flow Chart(invite attendee) (1)](https://user-images.githubusercontent.com/43316837/97198481-2147c780-17af-11eb-9628-1b8ea5f1dc7f.jpg)



When an orgonizer create an event and invite a list of attendee , an email will be sent with the details of invitation and generate links  for each actions depending of type of the attendee
**External Attendee**
Links action will be generated with excal 
![action linksExcal](https://user-images.githubusercontent.com/43316837/97195874-18a1c200-17ac-11eb-8e4b-feb2120941fb.png)
Each action redirect to EXCAL app (calendar public SPA)

**Internal User**
Links action will be generated with calendar
![calendarLink](https://user-images.githubusercontent.com/43316837/97196224-851cc100-17ac-11eb-832a-d06192e3c46e.png)
Each action redirect to Calendar app with new state called participation (with event id)

When the application redirect to participation state  , the modal of detail event will be opened 

