### PR TITLE
Fixes for calendar configurations dialog

### DIFF
--- a/src/linagora.esn.calendar/app/app.js
+++ b/src/linagora.esn.calendar/app/app.js
@@ -195,6 +195,7 @@ require('./search/form/search-form.controller.js');
 require('./search/search.run.js');
 require('./services/websocket/listener.run.js');
 require('./services/websocket/listener.service.js');
+require('./settings/settings.service');
 require('./settings/calendars/fab/create-calendar-menu-item/create-calendar-menu-item.component.js');
 require('./settings/calendars/fab/create-calendar-menu-item/create-calendar-menu-item.run.js');
 require('./settings/calendars/fab/import-calendar-menu-item/import-calendar-menu-item.component.js');

--- a/src/linagora.esn.calendar/app/settings/display/settings-display.controller.js
+++ b/src/linagora.esn.calendar/app/settings/display/settings-display.controller.js
@@ -10,6 +10,7 @@ function CalSettingsDisplayController(
   asyncAction,
   calFullUiConfiguration,
   esnUserConfigurationService,
+  calSettingsService,
   CAL_USER_CONFIGURATION
 ) {
   var self = this;
@@ -50,9 +51,15 @@ function CalSettingsDisplayController(
       };
     });
 
+    calSettingsService.updateStatus('updating');
+
     return esnUserConfigurationService.set(configurationsArray, CAL_USER_CONFIGURATION.moduleName)
       .then(function() {
+        calSettingsService.updateStatus('updated');
         calFullUiConfiguration.setHiddenDeclinedEvents(self.configurations.hideDeclinedEvents);
+      })
+      .catch(() => {
+        calSettingsService.updateStatus('failed');
       });
   }
 }

--- a/src/linagora.esn.calendar/app/settings/settings.service.js
+++ b/src/linagora.esn.calendar/app/settings/settings.service.js
@@ -1,0 +1,35 @@
+'use strict';
+
+angular.module('esn.calendar')
+  .service('calSettingsService', calSettingsService);
+
+function calSettingsService($rootScope, $state) {
+  const self = this;
+
+  self.status = 'initial';
+  self.forceUpdate = false;
+
+  return {
+    setForceUpdate,
+    getStatus,
+    updateStatus
+  };
+
+  function setForceUpdate(forceUpdate = true) {
+    self.forceUpdate = forceUpdate;
+  }
+
+  function getStatus() {
+    return self.status;
+  }
+
+  function updateStatus(newStatus, options) {
+    self.status = newStatus;
+
+    $rootScope.$broadcast('cal-settings:status:updated', self.status, options);
+
+    if (self.forceUpdate) {
+      $state.reload();
+    }
+  }
+}


### PR DESCRIPTION
@pbson This is the rough idea to prevent the page from reloading when switching between the dialog's tabs.