### PR TITLE
esn-frontend-calendar-public#20: Refactored the code to change participation status using jwt for internal users

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
   "dependencies": {
     "esn-dav-import-client": "github:openpaas-suite/esn-dav-import-client#main",
     "esn-frontend-common-libs": "github:openpaas-suite/esn-frontend-common-libs#main",
+    "esn-frontend-group": "github:openpaas-suite/esn-frontend-group#main",
     "esn-frontend-mailto-handler": "github:openpaas-suite/esn-frontend-mailto-handler#main",
     "esn-frontend-videoconference-calendar": "github:openpaas-suite/esn-frontend-videoconference-calendar#main",
-    "esn-frontend-group": "github:openpaas-suite/esn-frontend-group#main",
     "fullcalendar": "3.9.0",
-    "jquery-ui": "1.12.1"
+    "jquery-ui": "1.12.1",
+    "jwt-decode": "3.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",

--- a/src/esn.calendar.libs/app/app.module.js
+++ b/src/esn.calendar.libs/app/app.module.js
@@ -139,6 +139,7 @@ require('./services/grace-period-response-handler.js');
 require('./services/http-response-handler.js');
 require('./services/ical.js');
 require('./services/master-event-cache.js');
+require('./services/partstat-jwt.service.js');
 require('./services/partstat-update-notification.service.js');
 require('./services/path-builder.js');
 require('./services/path-parser.service.js');

--- a/src/esn.calendar.libs/app/services/event-service.js
+++ b/src/esn.calendar.libs/app/services/event-service.js
@@ -23,7 +23,6 @@ angular.module('esn.calendar.libs')
 function calEventService(
   $q,
   $http,
-  $log,
   $rootScope,
   ICAL,
   calCachedEventSource,
@@ -38,20 +37,16 @@ function calEventService(
   calMasterEventCache,
   calFreebusyHooksService,
   notificationFactory,
-  calOpenEventForm,
   esnI18nService,
-  calendarHomeService,
   CAL_GRACE_DELAY,
   CAL_GRACE_DELAY_IS_ACTIVE,
   CAL_EVENTS,
-  session,
-  httpConfigurer
+  session
 ) {
   var self = this;
   var oldEventStore = {};
 
   self.changeParticipation = changeParticipation;
-  self.changeParticipationFromLink = changeParticipationFromLink;
   self.sendCounter = sendCounter;
   self.getInvitedAttendees = getInvitedAttendees;
   self.getEvent = getEvent;
@@ -541,22 +536,6 @@ function calEventService(
   }
 
   /**
-   * Change the status of participation from external link
-   * @param {Mixed}    eventUid   the uid of event
-   * @param {Mixed}    jwt        jwt
-   */
-  function changeParticipationFromLink(eventUid, jwt) {
-    return $http({ method: 'GET', url: getChangeParticipationUrl(jwt) })
-      .then(() => calendarHomeService.getUserCalendarHomeId())
-      .then(calendarHomeId => getEventByUID(calendarHomeId, eventUid))
-      .then(event => calOpenEventForm(null, event))
-      .catch(err => {
-        $log.error('Can not display the requested event', err);
-        notificationFactory.weakError('Can not display the event');
-      });
-  }
-
-  /**
    * Answers to an invite with a counter proposal (suggesting another time)
    * @param  {CalendarShell}            suggestedEvent      the event in which we seek the attendees
    * See https://tools.ietf.org/html/rfc5546#page-86
@@ -595,9 +574,5 @@ function calEventService(
     return $http.get(url).then(function(response) {
       return new CalendarShell(ICAL.Component.fromString(response.data));
     });
-  }
-
-  function getChangeParticipationUrl(jwt) {
-    return `${httpConfigurer.getUrl('/calendar/api/calendars/event/participation')}?jwt=${jwt}`;
   }
 }

--- a/src/esn.calendar.libs/app/services/event-service.spec.js
+++ b/src/esn.calendar.libs/app/services/event-service.spec.js
@@ -1472,49 +1472,6 @@ describe('The calEventService service', function() {
     // Everything else is covered by the modify fn
   });
 
-  describe('the change participation from link', function() {
-
-    it('should open modal after successfully changing the participation status and open the appropriate event dialog', function() {
-      const eventUid = '123';
-      const jwt = '123';
-
-      this.$httpBackend.expectGET('/calendar/api/calendars/event/participation?jwt=123').respond({});
-      this.$httpBackend.when('REPORT', '/dav/api/calendars/1.json', { uid: '123' }).respond({
-        _links: {
-          self: { href: '/prepath/path/to/calendar.json' }
-        },
-        _embedded: {
-          'dav:item': [{
-            _links: {
-              self: { href: '/prepath/path/to/calendar/myuid.ics' }
-            },
-            etag: '"123123"',
-            data: [
-              'vcalendar', [], [
-                ['vevent', [
-                  ['uid', {}, 'text', 'myuid'],
-                  ['summary', {}, 'text', 'title'],
-                  ['location', {}, 'text', 'location'],
-                  ['dtstart', {}, 'date-time', '2014-01-01T02:03:04'],
-                  ['dtend', {}, 'date-time', '2014-01-01T03:03:04']
-                ], []]
-              ]
-            ]
-          }]
-        }
-      });
-      self.calEventService.changeParticipationFromLink(eventUid, jwt).then(function() {
-        self.$httpBackend.flush();
-        const stubArgs = calOpenEventFormMock.firstCall.args;
-
-        expect(calendarHomeServiceMock.getUserCalendarHomeId).to.have.been.called;
-        expect(calOpenEventFormMock).to.have.been.called;
-        expect(stubArgs[1].etag).to.eq('"123123"');
-      });
-    });
-
-  });
-
   describe('The getEventByUID fn', function() {
 
     it('should get a non-recurring event', function(done) {

--- a/src/esn.calendar.libs/app/services/partstat-jwt.service.js
+++ b/src/esn.calendar.libs/app/services/partstat-jwt.service.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const jwtDecode = require('jwt-decode');
+
+angular.module('esn.calendar.libs')
+  .service('calPartstatJWTService', calPartstatJWTService);
+
+/**
+ * This service contains the methods to change the participation status of a user for an event via a jwt
+ */
+function calPartstatJWTService($q, $http, $log, httpConfigurer, calEventService, calendarHomeService, calOpenEventForm, notificationFactory, calPartstatUpdateNotificationService) {
+  return {
+    changeParticipationUsingJWTAndDisplayEvent,
+    changeParticipationUsingJWT,
+    getChangeParticipationURL
+  };
+
+  /**
+   * Change a user's participation status for an event using a jwt and display the event details afterwards
+   * @param {String} jwt    The jwt that contains the information to change the user's participation status for an event
+   * @returns {Promise}     A promise that resolves when the process to change the participation status using a jwt finishes
+   */
+  function changeParticipationUsingJWTAndDisplayEvent(jwt) {
+    if (!jwt) {
+      const error = new Error('There is no jwt to change the participation status');
+
+      $log.error(error);
+      notificationFactory.weakError('', 'Event participation modification failed');
+
+      return $q.reject(error);
+    }
+
+    const { uid: eventUid, action } = jwtDecode.default(jwt);
+
+    return changeParticipationUsingJWT(jwt)
+      .then(() => {
+        calPartstatUpdateNotificationService(action);
+
+        return calendarHomeService.getUserCalendarHomeId()
+          .then(calendarHomeId => calEventService.getEventByUID(calendarHomeId, eventUid))
+          .then(event => calOpenEventForm(null, event))
+          .catch(err => {
+            $log.error('Cannot display the requested event', err);
+            notificationFactory.weakError('', 'Cannot display the event');
+          });
+      })
+      .catch(err => {
+        $log.error('Something went wrong while changing the participation status', err);
+        notificationFactory.weakError('', 'Event participation modification failed');
+      });
+  }
+
+  /**
+   * Send a request to change a user's participation status for an event using a jwt
+   * @param {String} jwt    The jwt that contains the information to change the user's participation status for an event
+   * @returns {Promise}     A promise that resolves when the request to change the participation status completes
+   */
+  function changeParticipationUsingJWT(jwt) {
+    return $http({ method: 'GET', url: getChangeParticipationURL(jwt) });
+  }
+
+  /**
+   * Get the url to change a user's participation status for an event using a jwt
+   * @param {String} jwt    The jwt that contains the information to change the user's participation status for an event
+   * @returns {String}      The url to change the participation status
+   */
+  function getChangeParticipationURL(jwt) {
+    return `${httpConfigurer.getUrl('/calendar/api/calendars/event/participation')}?jwt=${jwt}`;
+  }
+}

--- a/src/esn.calendar.libs/app/services/partstat-jwt.service.spec.js
+++ b/src/esn.calendar.libs/app/services/partstat-jwt.service.spec.js
@@ -1,0 +1,243 @@
+'use strict';
+
+/* global chai, sinon */
+
+const jwtDecode = require('jwt-decode');
+const { expect } = chai;
+
+describe('The calPartstatJWTService', function() {
+  let $rootScope, calPartstatJWTService, httpConfigurer;
+  let httpMock, notificationFactoryMock, calPartstatUpdateNotificationServiceMock, jwtDecodeStub, calendarHomeServiceMock, calEventServiceMock, calOpenEventFormMock, log;
+  let jwtDecodedContent, calendarHomeId, event;
+  let sandbox, error, rejectedPromise;
+
+  beforeEach(function() {
+    error = new Error('Something went wrong');
+    rejectedPromise = $q.reject(error);
+  });
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+
+    jwtDecodedContent = {};
+    jwtDecodeStub = sandbox.stub().returns(jwtDecodedContent);
+    jwtDecode.default = jwtDecodeStub;
+
+    httpMock = sandbox.stub().returns($q.when());
+
+    notificationFactoryMock = {
+      weakError: sandbox.stub()
+    };
+
+    calPartstatUpdateNotificationServiceMock = sandbox.stub();
+
+    calendarHomeId = 'calendarHomeId';
+
+    calendarHomeServiceMock = {
+      getUserCalendarHomeId: sandbox.stub().returns($q.when(calendarHomeId))
+    };
+
+    event = {};
+
+    calEventServiceMock = {
+      getEventByUID: sandbox.stub().returns($q.when(event))
+    };
+
+    calOpenEventFormMock = sandbox.stub();
+
+    angular.mock.module('esn.resource.libs');
+    angular.mock.module('esn.calendar.libs');
+    angular.mock.module(function($provide) {
+      $provide.value('$http', httpMock);
+      $provide.value('notificationFactory', notificationFactoryMock);
+      $provide.value('calPartstatUpdateNotificationService', calPartstatUpdateNotificationServiceMock);
+      $provide.value('calendarHomeService', calendarHomeServiceMock);
+      $provide.value('calEventService', calEventServiceMock);
+      $provide.value('calOpenEventForm', calOpenEventFormMock);
+    });
+  });
+
+  beforeEach(angular.mock.inject(function(_$rootScope_, _$log_, _calPartstatJWTService_, _httpConfigurer_) {
+    $rootScope = _$rootScope_;
+    calPartstatJWTService = _calPartstatJWTService_;
+    httpConfigurer = _httpConfigurer_;
+    log = _$log_;
+
+    httpConfigurer.getUrl = sandbox.stub().returnsArg(0);
+    log.error = sandbox.stub();
+  }));
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  describe('The getChangeParticipationURL function', function() {
+    it('should return the correct url to change the participation status', function() {
+      const jwt = 'jwt';
+      const changeParticipationURL = calPartstatJWTService.getChangeParticipationURL(jwt);
+
+      expect(httpConfigurer.getUrl).to.have.been.calledWith('/calendar/api/calendars/event/participation');
+      expect(changeParticipationURL).to.equal(`/calendar/api/calendars/event/participation?jwt=${jwt}`);
+    });
+  });
+
+  describe('The changeParticipationUsingJWT function', function() {
+    it('should send a request to change the participation status', function(done) {
+      const jwt = 'jwt';
+
+      calPartstatJWTService.changeParticipationUsingJWT(jwt)
+        .then(() => {
+          expect(httpMock).to.have.been.calledWith({ method: 'GET', url: `/calendar/api/calendars/event/participation?jwt=${jwt}` });
+          done();
+        })
+        .catch(err => done(err || new Error('should resolve')));
+
+      $rootScope.$digest();
+    });
+  });
+
+  describe('The changeParticipationUsingJWTAndDisplayEvent function', function() {
+    it('should reject and display an error message when no jwt is found', function(done) {
+      calPartstatJWTService.changeParticipationUsingJWTAndDisplayEvent()
+        .then(() => done('should not resolve'))
+        .catch(err => {
+          expect(err).to.exist;
+          expect(err.message).to.equal('There is no jwt to change the participation status');
+          expect(log.error).to.have.been.calledWith(err);
+          expect(notificationFactoryMock.weakError).to.have.been.calledWith('', 'Event participation modification failed');
+          done();
+        });
+
+      $rootScope.$digest();
+    });
+
+    it('should change participation status using the provided jwt and open the event form afterwards', function(done) {
+      const jwt = 'jwt';
+      const eventUid = 'eventUid';
+      const action = 'ACCEPTED';
+
+      jwtDecodedContent.uid = eventUid;
+      jwtDecodedContent.action = action;
+
+      calPartstatJWTService.changeParticipationUsingJWTAndDisplayEvent(jwt)
+        .then(() => {
+          expect(httpMock).to.have.been.calledWith({ method: 'GET', url: `/calendar/api/calendars/event/participation?jwt=${jwt}` });
+          expect(calPartstatUpdateNotificationServiceMock).to.have.been.calledWith(action);
+          expect(calendarHomeServiceMock.getUserCalendarHomeId).to.have.been.calledOnce;
+          expect(calEventServiceMock.getEventByUID).to.have.been.calledWith(calendarHomeId, eventUid);
+          expect(calOpenEventFormMock).to.have.been.calledWith(null, event);
+          done();
+        })
+        .catch(err => done(err || new Error('should resolve')));
+
+      expect(jwtDecodeStub).to.have.been.calledWith(jwt);
+
+      $rootScope.$digest();
+    });
+
+    it('should display an error notification when the request to change the participation status fails', function(done) {
+      const jwt = 'jwt';
+      const eventUid = 'eventUid';
+      const action = 'ACCEPTED';
+
+      jwtDecodedContent.uid = eventUid;
+      jwtDecodedContent.action = action;
+
+      httpMock.returns(rejectedPromise);
+
+      calPartstatJWTService.changeParticipationUsingJWTAndDisplayEvent(jwt)
+        .then(() => {
+          expect(httpMock).to.have.been.calledWith({ method: 'GET', url: `/calendar/api/calendars/event/participation?jwt=${jwt}` });
+          expect(calPartstatUpdateNotificationServiceMock).to.have.not.been.called;
+          expect(calendarHomeServiceMock.getUserCalendarHomeId).to.have.not.been.called;
+          expect(calEventServiceMock.getEventByUID).to.have.not.been.called;
+          expect(calOpenEventFormMock).to.have.not.been.called;
+          expect(notificationFactoryMock.weakError).to.have.been.calledWith('', 'Event participation modification failed');
+          done();
+        })
+        .catch(err => done(err || new Error('should resolve')));
+
+      expect(jwtDecodeStub).to.have.been.calledWith(jwt);
+
+      $rootScope.$digest();
+    });
+
+    it('should display an error notification when it fails to get the user calendar home id', function(done) {
+      const jwt = 'jwt';
+      const eventUid = 'eventUid';
+      const action = 'ACCEPTED';
+
+      jwtDecodedContent.uid = eventUid;
+      jwtDecodedContent.action = action;
+
+      calendarHomeServiceMock.getUserCalendarHomeId = sandbox.stub().returns(rejectedPromise);
+
+      calPartstatJWTService.changeParticipationUsingJWTAndDisplayEvent(jwt)
+        .then(() => {
+          expect(httpMock).to.have.been.calledWith({ method: 'GET', url: `/calendar/api/calendars/event/participation?jwt=${jwt}` });
+          expect(calPartstatUpdateNotificationServiceMock).to.have.been.calledWith(action);
+          expect(calendarHomeServiceMock.getUserCalendarHomeId).to.have.been.calledOnce;
+          expect(notificationFactoryMock.weakError).to.have.been.calledWith('', 'Cannot display the event');
+          done();
+        })
+        .catch(err => done(err || new Error('should resolve')));
+
+      expect(jwtDecodeStub).to.have.been.calledWith(jwt);
+
+      $rootScope.$digest();
+    });
+
+    it('should display an error notification when it fails to fetch the event', function(done) {
+      const jwt = 'jwt';
+      const eventUid = 'eventUid';
+      const action = 'ACCEPTED';
+
+      jwtDecodedContent.uid = eventUid;
+      jwtDecodedContent.action = action;
+
+      calEventServiceMock.getEventByUID = sandbox.stub().returns(rejectedPromise);
+
+      calPartstatJWTService.changeParticipationUsingJWTAndDisplayEvent(jwt)
+        .then(() => {
+          expect(httpMock).to.have.been.calledWith({ method: 'GET', url: `/calendar/api/calendars/event/participation?jwt=${jwt}` });
+          expect(calPartstatUpdateNotificationServiceMock).to.have.been.calledWith(action);
+          expect(calendarHomeServiceMock.getUserCalendarHomeId).to.have.been.calledOnce;
+          expect(calEventServiceMock.getEventByUID).to.have.been.calledWith(calendarHomeId, eventUid);
+          expect(notificationFactoryMock.weakError).to.have.been.calledWith('', 'Cannot display the event');
+          done();
+        })
+        .catch(err => done(err || new Error('should resolve')));
+
+      expect(jwtDecodeStub).to.have.been.calledWith(jwt);
+
+      $rootScope.$digest();
+    });
+
+    it('should display an error notification when it fails to open the event form', function(done) {
+      const jwt = 'jwt';
+      const eventUid = 'eventUid';
+      const action = 'ACCEPTED';
+
+      jwtDecodedContent.uid = eventUid;
+      jwtDecodedContent.action = action;
+
+      calOpenEventFormMock.returns(rejectedPromise);
+
+      calPartstatJWTService.changeParticipationUsingJWTAndDisplayEvent(jwt)
+        .then(() => {
+          expect(httpMock).to.have.been.calledWith({ method: 'GET', url: `/calendar/api/calendars/event/participation?jwt=${jwt}` });
+          expect(calPartstatUpdateNotificationServiceMock).to.have.been.calledWith(action);
+          expect(calendarHomeServiceMock.getUserCalendarHomeId).to.have.been.calledOnce;
+          expect(calEventServiceMock.getEventByUID).to.have.been.calledWith(calendarHomeId, eventUid);
+          expect(calOpenEventFormMock).to.have.been.calledWith(null, event);
+          expect(notificationFactoryMock.weakError).to.have.been.calledWith('', 'Cannot display the event');
+          done();
+        })
+        .catch(err => done(err || new Error('should resolve')));
+
+      expect(jwtDecodeStub).to.have.been.calledWith(jwt);
+
+      $rootScope.$digest();
+    });
+  });
+});

--- a/src/esn.calendar.libs/i18n/en.json
+++ b/src/esn.calendar.libs/i18n/en.json
@@ -66,6 +66,7 @@
   "Can not subscribe to calendar": "Can not subscribe to calendar",
   "Can not subscribe to calendars": "Can not subscribe to calendars",
   "Cannot access private event": "Cannot access private event",
+  "Cannot display the event": "Cannot display the event",
   "Cannot go": "Cannot go",
   "Cannot join the server, please try later": "Cannot join the server, please try later",
   "Cannot retrieve attendee availability": "Cannot retrieve attendee availability",

--- a/src/esn.calendar.libs/i18n/fr.json
+++ b/src/esn.calendar.libs/i18n/fr.json
@@ -66,6 +66,7 @@
   "Can not subscribe to calendar": "Impossible de s'abonner au calendrier",
   "Can not subscribe to calendars": "Impossible de s'abonner aux calendriers",
   "Cannot access private event": "Vous n'avez pas accès à cet événement privé",
+  "Cannot display the event": "Impossible d'afficher l'événement",
   "Cannot go": "Je ne participe pas",
   "Cannot join the server, please try later": "Impossible de joindre le serveur, essayez plus tard",
   "Cannot retrieve attendee availability": "Impossible de récupérer la disponibilité du participant",

--- a/src/esn.calendar.libs/i18n/ru.json
+++ b/src/esn.calendar.libs/i18n/ru.json
@@ -66,6 +66,7 @@
   "Can not subscribe to calendar": "Невозможно подписаться на календарь",
   "Can not subscribe to calendars": "Невозможно подписаться на календари",
   "Cannot access private event": "Невозможно получить доступ к приватному событию",
+  "Cannot display the event": "Невозможно отобразить событие",
   "Cannot go": "Невозможно запустить",
   "Cannot join the server, please try later": "Не удается присоединиться к серверу, попробуйте позже",
   "Cannot retrieve attendee availability": "Не удалось получить данные о доступности участника",

--- a/src/esn.calendar.libs/i18n/vi.json
+++ b/src/esn.calendar.libs/i18n/vi.json
@@ -66,6 +66,7 @@
   "Can not subscribe to calendar": "Không thể đăng ký vào lịch",
   "Can not subscribe to calendars": "Không thể đăng ký vào lịch",
   "Cannot access private event": "Không thể truy cập sự kiện riêng tư",
+  "Cannot display the event": "Không thể hiển thị sự kiện",
   "Cannot go": "Không tham gia",
   "Cannot join the server, please try later": "Không thể kết nối tới server, vui lòng thử lại sau",
   "Cannot retrieve attendee availability": "Tính khả dụng của người tham dự không xác định",

--- a/src/esn.calendar.libs/i18n/zh.json
+++ b/src/esn.calendar.libs/i18n/zh.json
@@ -66,6 +66,7 @@
   "Can not subscribe to calendar": "无法订阅日历",
   "Can not subscribe to calendars": "无法订阅日历组",
   "Cannot access private event": "无法进入私人事件",
+  "Cannot display the event": "无法显示事件",
   "Cannot go": "无法前往",
   "Cannot join the server, please try later": "无法进入服务器，请稍后再试",
   "Cannot retrieve attendee availability": "无法获取参与者时间安排信息",

--- a/src/linagora.esn.calendar/app/routes.js
+++ b/src/linagora.esn.calendar/app/routes.js
@@ -34,19 +34,12 @@ function routesConfig($stateProvider) {
     })
     .state('calendar.main.participation', {
       url: '/participation',
-      resolve: {
-        event: function($log, $state, $location, notificationFactory, calEventService) {
-          const { jwt, eventUid } = $location.search();
+      onEnter: function($state, $location, calPartstatJWTService) {
+        const { jwt } = $location.search();
 
-          if (jwt && eventUid) {
-            calEventService.changeParticipationFromLink(eventUid, jwt)
-              .catch(err => {
-                $log.error('Can not display the requested event', err);
-                notificationFactory.weakError(null, 'Can not display the event');
-                $state.go('calendar.main');
-              });
-          }
-        }
+        $state.go('calendar.main');
+
+        calPartstatJWTService.changeParticipationUsingJWTAndDisplayEvent(jwt);
       }
     })
     .state('calendar.main.planning', {


### PR DESCRIPTION
Continues to resolve https://github.com/OpenPaaS-Suite/esn-frontend-calendar-public/issues/20.

- Demo: https://streamable.com/qrtm51
