### PR TITLE
Static assets now have static names

### DIFF
--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -195,7 +195,10 @@ module.exports = {
         test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
         use: [
           {
-            loader: 'file-loader'
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]'
+            }
           }
         ]
       },


### PR DESCRIPTION
Context: We need these assets to have the same names each time we build the app so that we can load them in https://github.com/OpenPaaS-Suite/openpaas-gatling. I think this should be OK. Those are the assets that we do not frequently update so it's perfectly fine not to have a hash for them. Even if we have a problem with the browser's cache, it should not affect much (as long as the JavaScript files get updated).

![image](https://user-images.githubusercontent.com/24670327/100219944-3bf59380-2f49-11eb-957d-f6f5a130f5da.png)