### PR TITLE
fixed failing to open the event when the alarm has no attendee

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
@@ -160,7 +160,7 @@ function CalEventFormController(
       $scope.canSuggestTime = calEventUtils.canSuggestChanges($scope.editedEvent, session.user);
       $scope.inputSuggestions = _.filter($scope.relatedEvents, { type: CAL_RELATED_EVENT_TYPES.COUNTER });
 
-      if ($scope.event.alarm) {
+      if ($scope.event.alarm && $scope.event.alarm.attendee && $scope.event.alarm.trigger) {
         $scope.editedEvent.alarm = $scope.event.alarm;
       }
 


### PR DESCRIPTION
when opening an event with weird alarm:

```js
Error: invalid alarm set value, missing trigger or attendee
    at y.set alarm [as alarm] (calendar-shell.js:445)
    at n (event-form.controller.js:164)
    at n.s.initFormData (event-form.controller.js:144)
    at s (event-form.controller.js:97)
    at Object.s [as invoke] (angular.js:4219)
```