### PR TITLE
#343 fixed shared calendars names with edit permission colliding with each other when selecting a calendar

### DIFF
--- a/src/esn.calendar.libs/app/components/select-calendar/select-calendar-item.less
+++ b/src/esn.calendar.libs/app/components/select-calendar/select-calendar-item.less
@@ -7,7 +7,7 @@
   }
 
   .info {
-    .flex-column;
+    .flex;
 
     >span {
       font-size: 13px;
@@ -20,7 +20,8 @@
       font-size: 12px;
 
       .separator {
-        display: none;
+        padding-left: 6px;
+        padding-right: 6px;
       }
     }
   }


### PR DESCRIPTION
## before

![image](https://user-images.githubusercontent.com/6764881/109270122-e366b880-780d-11eb-8044-73181b532986.png)


## after

![image](https://user-images.githubusercontent.com/6764881/109270233-042f0e00-780e-11eb-8fe6-07c635f00bb6.png)
