### PR TITLE
#371: Now the event preview popover displays properly for an event with no title/summary

### DIFF
--- a/src/esn.calendar.libs/app/components/event-preview-popover/event-preview-popover.pug
+++ b/src/esn.calendar.libs/app/components/event-preview-popover/event-preview-popover.pug
@@ -20,7 +20,8 @@
   button.btn.btn-link.btn-icon.waves-notransition.waves-effect.waves-light.waves-circle(ng-click="$ctrl.closeEventPreviewPopover()", title="{{ 'Close' | translate }}", bs-tooltip)
     i.mdi.mdi-close
 .event-preview-popover-body-container
-  h1.event-summary {{ $ctrl.event.summary }}
+  h1.event-summary(ng-if="$ctrl.event.summary") {{ $ctrl.event.summary }}
+  h1.event-summary(ng-if="!$ctrl.event.summary") {{ 'No title' | translate }}
   p.event-date-time {{ [$ctrl.event.start, $ctrl.event.end] | eventDateTimeFormat }}
   .info-row.video-conference-row(ng-if="$ctrl.event.xOpenpaasVideoconference")
     i.mdi.mdi-video


### PR DESCRIPTION
Continues to resolve #371.

![image](https://user-images.githubusercontent.com/24670327/110570399-64b43880-8188-11eb-9c2d-176cec92ce40.png)
