### PR TITLE
#456: Now the footer of the event dialog is displayed properly in mobile devices

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.less
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.less
@@ -67,6 +67,10 @@ body  {
     cursor: grabbing;
   }
 
+  .modal-footer {
+    background: inherit;
+  }
+
   .modal-body {
     .message {
       color: @secondaryTextColor;


### PR DESCRIPTION
Resolves #456.

- Before:

![Screenshot_20210312_113520_com android chrome](https://user-images.githubusercontent.com/24670327/110892883-75e77b80-8327-11eb-8f69-42d1ee8938f4.jpg)

- After:

![Screenshot_20210312_113437_com android chrome](https://user-images.githubusercontent.com/24670327/110892877-741db800-8327-11eb-8a16-50d180524596.jpg)