### PR TITLE
#306: Now the description field is not cropped in mobile devices

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.less
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.less
@@ -69,6 +69,7 @@ body  {
 
   .modal-footer {
     background: inherit;
+    z-index: 10;
   }
 
   .modal-body {
@@ -143,6 +144,7 @@ body  {
           top: unset;
           bottom: unset;
           max-height: calc(100vh - 109px);
+          padding-bottom: 48px;
         }
       }
     }


### PR DESCRIPTION
Resolves #306.

- Before:

![Screenshot_20210312_152603_com android chrome](https://user-images.githubusercontent.com/24670327/110913187-67a95780-8347-11eb-8a03-cbf15d223048.jpg)

- After:

![Screenshot_20210312_152354_com android chrome](https://user-images.githubusercontent.com/24670327/110913202-6bd57500-8347-11eb-9d2b-3b74a1624e19.jpg)
