### PR TITLE
esn-frontend-calendar#487: Fixed an issue where the last field in the event form is not shown fully in Safari

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.less
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.less
@@ -144,7 +144,7 @@ body  {
           top: unset;
           bottom: unset;
           max-height: calc(100vh - 109px);
-          padding-bottom: 48px;
+          padding-bottom: 72px;
         }
       }
     }


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/487.

- Before:

![before](https://user-images.githubusercontent.com/24670327/112928414-cb51c400-9140-11eb-91d5-0c9d2089a433.png)

- After:

![after](https://user-images.githubusercontent.com/24670327/112928420-ce4cb480-9140-11eb-92f1-1de7f70cea01.png)