### PR TITLE
#508: Fixed an issue where the event preview popover displays the incorrect name and color of a publicly shared calendar

### DIFF
--- a/src/esn.calendar.libs/app/components/event-preview-popover/event-preview-popover.component.js
+++ b/src/esn.calendar.libs/app/components/event-preview-popover/event-preview-popover.component.js
@@ -8,6 +8,7 @@ angular.module('esn.calendar.libs')
     template: require('./event-preview-popover.pug'),
     controller: 'CalEventPreviewPopoverController',
     bindings: {
-      event: '='
+      event: '=',
+      calendarHomeId: '<'
     }
   });

--- a/src/esn.calendar.libs/app/components/event-preview-popover/event-preview-popover.controller.js
+++ b/src/esn.calendar.libs/app/components/event-preview-popover/event-preview-popover.controller.js
@@ -175,7 +175,12 @@ function CalEventPreviewPopoverController(
   }
 
   function _fetchCalendarAndRights() {
-    calendarService.getCalendar(self.event.calendarHomeId, self.event.calendarId)
+    calendarService.listPersonalAndAcceptedDelegationCalendars(self.calendarHomeId)
+      .then(calendars => calendars.find(calendar => {
+        if (!calendar.source) return calendar.uniqueId === self.event.calendarUniqueId;
+
+        return calendar.source.uniqueId === self.event.calendarUniqueId || calendar.uniqueId === self.event.calendarUniqueId;
+      }))
       .then(calendar => {
         self.calendar = calendar;
 

--- a/src/esn.calendar.libs/app/components/event-preview-popover/event-preview-popover.controller.spec.js
+++ b/src/esn.calendar.libs/app/components/event-preview-popover/event-preview-popover.controller.spec.js
@@ -19,7 +19,7 @@ describe('The CalEventPreviewPopoverController', function() {
     calOpenEventFormMock = sinon.stub();
 
     calendarServiceMock = {
-      getCalendar: sinon.stub().returns($q.when({ id: 'calendarId', calendarHomeId: 'calendarHomeId', getOwner: () => $q.when({ id: 'owner' }) }))
+      listPersonalAndAcceptedDelegationCalendars: sinon.stub().returns($q.when([{ id: 'calendarId', calendarHomeId: 'calendarHomeId', getOwner: () => $q.when({ id: 'owner' }) }]))
     };
 
     calEventServiceMock = {
@@ -111,7 +111,8 @@ describe('The CalEventPreviewPopoverController', function() {
         attendees: [{ email: 'attendee1@mail.test' }, { email: 'attendee2@mail.test' }],
         location: 'https://test.com',
         calendarHomeId: 'calendarHomeId',
-        calendarId: 'calendarId'
+        calendarId: 'calendarId',
+        calendarUniqueId: '/calendarHomeId/calendarId.json'
       };
     });
 
@@ -157,13 +158,13 @@ describe('The CalEventPreviewPopoverController', function() {
       const owner = { id: 'owner' };
       const userAttendee = { id: 'calendarHomeId', email: 'attendee1@mail.test' };
       const calendar = {
-        id: 'calendarId', calendarHomeId: 'calendarHomeId', getOwner: () => $q.when(owner), readOnly: false
+        id: 'calendarId', calendarHomeId: event.calendarHomeId, uniqueId: event.calendarUniqueId, getOwner: () => $q.when(owner), readOnly: false
       };
 
-      calendarServiceMock.getCalendar = sinon.stub().returns($q.when(calendar));
+      calendarServiceMock.listPersonalAndAcceptedDelegationCalendars = sinon.stub().returns($q.when([calendar]));
       calAttendeeServiceMock.getAttendeeForUser = sinon.stub().returns(userAttendee);
 
-      controller = initController({ event });
+      controller = initController({ event, calendarHomeId: calendar.calendarHomeId });
 
       expect(scope.$watch).to.have.been.calledTwice;
 
@@ -174,7 +175,53 @@ describe('The CalEventPreviewPopoverController', function() {
 
       listener();
 
-      expect(calendarServiceMock.getCalendar).to.have.been.calledWith(controller.event.calendarHomeId, controller.event.calendarId);
+      expect(calendarServiceMock.listPersonalAndAcceptedDelegationCalendars).to.have.been.calledWith(controller.event.calendarHomeId);
+
+      $rootScope.$digest();
+
+      expect(controller.calendar).to.equal(calendar);
+
+      $rootScope.$digest();
+
+      expect(calAttendeeServiceMock.getAttendeeForUser).to.have.been.calledWith(controller.event.attendees, owner);
+      expect(controller.calendarOwnerAsAttendee).to.equal(userAttendee);
+
+      $rootScope.$digest();
+
+      expect(calUIAuthorizationServiceMock.canModifyEvent).to.have.been.calledWith(controller.calendar, controller.event, sessionUser._id);
+      expect(controller.canModifyEvent).to.be.true;
+      expect(controller.isReadOnly).to.equal(calendar.readOnly);
+    });
+
+    it('should fetch calendar and rights and set the calendar correctly when it is a shared calendar', function() {
+      const owner = { id: 'owner' };
+      const userAttendee = { id: 'calendarHomeId', email: 'attendee1@mail.test' };
+      const calendar = {
+        id: 'calendarId',
+        calendarHomeId: 'anotherCalendarHomeId',
+        uniqueId: 'anotherCalendarHomeId/calendarId.json',
+        getOwner: () => $q.when(owner),
+        readOnly: false,
+        source: {
+          uniqueId: event.calendarUniqueId
+        }
+      };
+
+      calendarServiceMock.listPersonalAndAcceptedDelegationCalendars = sinon.stub().returns($q.when([calendar]));
+      calAttendeeServiceMock.getAttendeeForUser = sinon.stub().returns(userAttendee);
+
+      controller = initController({ event, calendarHomeId: calendar.calendarHomeId });
+
+      expect(scope.$watch).to.have.been.calledTwice;
+
+      const detectChangeFunction = scope.$watch.getCall(0).args[0];
+      const listener = scope.$watch.getCall(0).args[1];
+
+      expect(detectChangeFunction()).to.equal(controller.event);
+
+      listener();
+
+      expect(calendarServiceMock.listPersonalAndAcceptedDelegationCalendars).to.have.been.calledWith(calendar.calendarHomeId);
 
       $rootScope.$digest();
 
@@ -207,7 +254,7 @@ describe('The CalEventPreviewPopoverController', function() {
       expect(calEventUtilsMock.getEmailAddressesFromAttendeesExcludingCurrentUser).to.have.not.been.called;
       expect(urlUtilsMock.isValidURL).to.have.not.been.called;
       expect(urlUtilsMock.isAbsoluteURL).to.have.not.been.called;
-      expect(calendarServiceMock.getCalendar).to.have.not.been.called;
+      expect(calendarServiceMock.listPersonalAndAcceptedDelegationCalendars).to.have.not.been.called;
     });
   });
 

--- a/src/esn.calendar.libs/app/services/event-preview-popover.service.js
+++ b/src/esn.calendar.libs/app/services/event-preview-popover.service.js
@@ -12,10 +12,10 @@ function calEventPreviewPopoverService($rootScope, $compile) {
     close
   };
 
-  function open({ targetElement, event }) {
+  function open({ targetElement, event, calendarHomeId }) {
     if (!scope) scope = $rootScope.$new();
 
-    scope.$ctrl = { event };
+    scope.$ctrl = { event, calendarHomeId };
 
     scope.$digest();
 
@@ -61,7 +61,7 @@ function calEventPreviewPopoverService($rootScope, $compile) {
   }
 
   function _createEventPreviewPopoverElement() {
-    eventPreviewPopoverElement = $compile('<event-preview-popover event="$ctrl.event" />')(scope);
+    eventPreviewPopoverElement = $compile('<event-preview-popover event="$ctrl.event" calendar-home-id="$ctrl.calendarHomeId" />')(scope);
 
     $(document.body).append(eventPreviewPopoverElement);
 

--- a/src/esn.calendar.libs/app/services/event-preview-popover.service.spec.js
+++ b/src/esn.calendar.libs/app/services/event-preview-popover.service.spec.js
@@ -7,7 +7,7 @@ const { expect } = chai;
 describe('The calEventPreviewPopoverService', function() {
   let $rootScope, calEventPreviewPopoverService;
   let $compileMock, $compileReturnStub, jQueryAppendStub;
-  let scope, eventPreviewPopoverElement, targetElement, event;
+  let scope, eventPreviewPopoverElement, targetElement, event, calendarHomeId;
 
   beforeEach(function() {
     eventPreviewPopoverElement = {
@@ -39,6 +39,7 @@ describe('The calEventPreviewPopoverService', function() {
 
     targetElement = { id: 'some-dom-element' };
     event = { uid: 'some-event-uid' };
+    calendarHomeId = 'calendarHomeId';
   });
 
   beforeEach(function() {
@@ -51,12 +52,12 @@ describe('The calEventPreviewPopoverService', function() {
 
   describe('The open function', function() {
     it('should create a new popover element if it has not been created yet', function() {
-      calEventPreviewPopoverService.open({ targetElement, event });
+      calEventPreviewPopoverService.open({ targetElement, event, calendarHomeId });
 
       expect($rootScope.$new).to.have.been.calledOnce;
       expect(scope.$digest).to.have.been.calledTwice;
-      expect(scope.$ctrl).to.deep.equal({ event });
-      expect($compileMock).to.have.been.calledWith('<event-preview-popover event="$ctrl.event" />');
+      expect(scope.$ctrl).to.deep.equal({ event, calendarHomeId });
+      expect($compileMock).to.have.been.calledWith('<event-preview-popover event="$ctrl.event" calendar-home-id="$ctrl.calendarHomeId" />');
       expect($compileReturnStub).to.have.been.calledWith(scope);
       expect(jQueryAppendStub).to.have.been.calledWith(eventPreviewPopoverElement);
       expect(eventPreviewPopoverElement.show).to.have.been.calledOnce;
@@ -69,14 +70,14 @@ describe('The calEventPreviewPopoverService', function() {
     });
 
     it('should just show the existing popover element when it has been created', function() {
-      calEventPreviewPopoverService.open({ targetElement, event });
-      calEventPreviewPopoverService.open({ targetElement, event });
+      calEventPreviewPopoverService.open({ targetElement, event, calendarHomeId });
+      calEventPreviewPopoverService.open({ targetElement, event, calendarHomeId });
 
       expect($rootScope.$new).to.have.been.calledOnce;
       expect(scope.$digest.callCount).to.equal(3);
-      expect(scope.$ctrl).to.deep.equal({ event });
+      expect(scope.$ctrl).to.deep.equal({ event, calendarHomeId });
       expect($compileMock).to.have.been.calledOnce;
-      expect($compileMock).to.have.been.calledWith('<event-preview-popover event="$ctrl.event" />');
+      expect($compileMock).to.have.been.calledWith('<event-preview-popover event="$ctrl.event" calendar-home-id="$ctrl.calendarHomeId" />');
       expect($compileReturnStub).to.have.been.calledOnce;
       expect($compileReturnStub).to.have.been.calledWith(scope);
       expect(jQueryAppendStub).to.have.been.calledOnce;

--- a/src/linagora.esn.calendar/app/calendar/calendar-view/calendar-view.controller.js
+++ b/src/linagora.esn.calendar/app/calendar/calendar-view/calendar-view.controller.js
@@ -163,7 +163,7 @@ const _ = require('lodash');
     function eventClick(event, jsEvent) {
       if (detectUtils.isMobile()) return calOpenEventForm($scope.calendarHomeId, event.clone());
 
-      calEventPreviewPopoverService.open({ targetElement: jsEvent.target, event: event.clone() });
+      calEventPreviewPopoverService.open({ targetElement: jsEvent.target, event: event.clone(), calendarHomeId: $scope.calendarHomeId });
     }
 
     function eventDropAndResize(drop, event, delta, revert) {

--- a/src/linagora.esn.calendar/app/calendar/calendar-view/calendar-view.controller.spec.js
+++ b/src/linagora.esn.calendar/app/calendar/calendar-view/calendar-view.controller.spec.js
@@ -1194,7 +1194,7 @@ describe('The calendarViewController', function() {
 
       expect(event.clone).to.have.been.called;
       expect(this.calOpenEventFormMock).to.have.not.been.called;
-      expect(calEventPreviewPopoverServiceMock.open).to.have.been.calledWith({ targetElement: jsEvent.target, event: clonedEvent });
+      expect(calEventPreviewPopoverServiceMock.open).to.have.been.calledWith({ targetElement: jsEvent.target, event: clonedEvent, calendarHomeId: this.scope.calendarHomeId });
     });
 
     it('should open the event dialog if it is a mobile device', function() {


### PR DESCRIPTION
Resolves #508.

![image](https://user-images.githubusercontent.com/24670327/113655633-69570880-96c4-11eb-8d81-55765e6651c9.png)
