### PR TITLE
#625 add show and hide radio button to calendars list

### DIFF
--- a/src/esn.calendar.libs/app/app.constants.js
+++ b/src/esn.calendar.libs/app/app.constants.js
@@ -157,6 +157,7 @@
     .constant('CAL_ATTENDEE_LIST_LIMIT', 5)
 
     .constant('CAL_AVAILABLE_VIEWS', ['agendaWeek', 'agendaDay', 'month', 'agendaThreeDays', 'basicDay'])
+    .constant('TOGGLE_TRANSITION', 200)
 
     .constant('CAL_CALENDAR_SHARED_RIGHT', {
       NONE: '0',

--- a/src/esn.calendar.libs/app/services/calendar-visibility.spec.js
+++ b/src/esn.calendar.libs/app/services/calendar-visibility.spec.js
@@ -116,6 +116,46 @@ describe('The calendarVisibilityService', function() {
     });
   });
 
+
+
+  describe('the showAndHideCalendars function', function() {
+    it('should broadcast the calendar and it new display status', function() {
+      var cal = this.getCalendar(42);
+
+      this.$rootScope.$broadcast = sinon.spy(this.$rootScope.$broadcast);
+
+      this.calendarVisibilityService.toggle(cal);
+      this.$rootScope.$digest();
+      expect(this.$rootScope.$broadcast).to.have.been.calledWith(
+        this.CAL_EVENTS.CALENDARS.TOGGLE_VIEW,
+        { calendarUniqueId: cal.uniqueId, hidden: true }
+      );
+
+      this.$rootScope.$broadcast.reset();
+
+      this.calendarVisibilityService.toggle(cal);
+      this.$rootScope.$digest();
+      expect(this.$rootScope.$broadcast).to.have.been.calledWith(
+        this.CAL_EVENTS.CALENDARS.TOGGLE_VIEW,
+        { calendarUniqueId: cal.uniqueId, hidden: false }
+      );
+    });
+
+    it('should correctly record hidden calendar in localforage', function() {
+      var id1 = '1';
+      var id2 = '2';
+      var hiddenCalendars = [this.getCalendar(id1), this.getCalendar(id2)];
+      var thenSpy = sinon.spy();
+
+      hiddenCalendars.map(this.calendarVisibilityService.toggle);
+      this.$rootScope.$digest();
+      this.calendarVisibilityService.getHiddenCalendars().then(thenSpy);
+      this.$rootScope.$digest();
+
+      expect(thenSpy).to.have.been.calledWith([id1, id2]);
+    });
+  });
+
   describe('The isHidden function', function() {
     it('should return true if and only if the calendar is hidden', function() {
       var cal = this.getCalendar(42);

--- a/src/linagora.esn.calendar/app/app.js
+++ b/src/linagora.esn.calendar/app/app.js
@@ -132,6 +132,7 @@ require('./components/calendar-today-button/calendar-today-button.controller.js'
 require('./components/calendar/calendar.component.js');
 require('./components/calendar/calendar.controller.js');
 require('./components/calendars-list/calendars-list.component.js');
+require('./components/calendars-list/calendar-list-toggle.directive.js');
 require('./components/calendars-list/calendars-list.controller.js');
 require('./components/calendars-list/external/external-calendars-list.component.js');
 require('./components/calendars-list/items/calendars-list-items.component.js');
@@ -141,6 +142,8 @@ require('./components/calendars-list/items/item/calendars-list-item.controller.j
 require('./components/calendars-list/items/item/configuration/calendars-list-item-configuration.component.js');
 require('./components/calendars-list/items/item/configuration/calendars-list-item-configuration.controller.js');
 require('./components/calendars-list/user/user-calendars-list.component.js');
+require('./components/calendars-list/user/user-calendars-list.controller.js');
+
 require('./components/event-alarm-consultation/event-alarm-consultation.component.js');
 require('./components/event-alarm-consultation/event-alarm-consultation.controller.js');
 require('./components/event-create-button/event-create-button.component.js');

--- a/src/linagora.esn.calendar/app/components/calendars-list/calendar-list-toggle.directive.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/calendar-list-toggle.directive.js
@@ -1,0 +1,25 @@
+
+'use strict';
+
+angular.module('esn.calendar')
+
+  .directive('calendarListToggle', function(TOGGLE_TRANSITION) {
+
+    return {
+      restrict: 'A',
+      link: function(scope, element, attrs) {
+        if (attrs.toggled === 'true') {
+          _toggle(0);
+        }
+
+        element.click(function() {
+          _toggle(TOGGLE_TRANSITION);
+        });
+
+        function _toggle(toggleTransistion) {
+          element.parent().parent().parent().toggleClass('toggled');
+          element.parent().parent().parent().find('ul:not(".not-toggled")').stop(true, false).slideToggle(toggleTransistion);
+        }
+      }
+    };
+  });

--- a/src/linagora.esn.calendar/app/components/calendars-list/calendars-list.controller.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/calendars-list.controller.js
@@ -1,3 +1,4 @@
+/* eslint-disable space-before-blocks */
 const _ = require('lodash');
 
 (function(angular) {
@@ -6,7 +7,7 @@ const _ = require('lodash');
   angular.module('esn.calendar')
     .controller('CalendarsListController', CalendarsListController);
 
-  function CalendarsListController(
+  function CalendarsListController (
     $rootScope,
     $scope,
     $q,
@@ -15,6 +16,7 @@ const _ = require('lodash');
     session,
     userAndExternalCalendars,
     CAL_EVENTS
+
   ) {
     var self = this;
 
@@ -30,6 +32,10 @@ const _ = require('lodash');
       self.sharedCalendars = [];
       self.hiddenCalendars = {};
       self.toggleCalendar = calendarVisibilityService.toggle;
+      self.selectAllCalendars = selectAllCalendars;
+      self.calendarsToggled = false;
+      self.sharedCalendarsLength = 0;
+      self.userCalendarsLength = 0;
 
       self.activate();
     }
@@ -42,14 +48,23 @@ const _ = require('lodash');
           var destroyCalRemoveEvent = $rootScope.$on(CAL_EVENTS.CALENDARS.REMOVE, onCalendarRemoved);
           var destroyCalUpdateEvent = $rootScope.$on(CAL_EVENTS.CALENDARS.UPDATE, onCalendarUpdated);
           var deregister = $rootScope.$on(CAL_EVENTS.CALENDARS.TOGGLE_VIEW, function(event, data) {
-            self.hiddenCalendars[data.calendarUniqueId] = data.hidden;
+            self.hiddenCalendars[data.calendarType + data.calendarUniqueId] = data.hidden;
           });
 
           $scope.$on('$destroy', destroyCalAddEvent);
           $scope.$on('$destroy', destroyCalRemoveEvent);
           $scope.$on('$destroy', destroyCalUpdateEvent);
           $scope.$on('$destroy', deregister);
+
         });
+    }
+
+    function selectAllCalendars(calendarType, status) {
+      const calendars = userAndExternalCalendars(self.calendars);
+
+      calendars[calendarType].forEach(function (calendar) {
+        calendarVisibilityService.showAndHideCalendars(calendar, status, calendarType);
+      });
     }
 
     function listCalendars() {
@@ -100,6 +115,8 @@ const _ = require('lodash');
       self.userCalendars = calendars.userCalendars;
       self.sharedCalendars = calendars.sharedCalendars;
       self.publicCalendars = calendars.publicCalendars;
+      self.sharedCalendarsLength = self.sharedCalendars.length;
+      self.userCalendarsLength = self.userCalendars.length;
     }
   }
 })(angular);

--- a/src/linagora.esn.calendar/app/components/calendars-list/calendars-list.less
+++ b/src/linagora.esn.calendar/app/components/calendars-list/calendars-list.less
@@ -79,7 +79,7 @@
 
           .mdi {
             font-size: 24px;
-            color: @primaryColor;
+            color: grey;
           }
         }
 

--- a/src/linagora.esn.calendar/app/components/calendars-list/calendars-list.pug
+++ b/src/linagora.esn.calendar/app/components/calendars-list/calendars-list.pug
@@ -2,7 +2,10 @@
   cal-user-calendars-list(
     user-calendars="$ctrl.userCalendars",
     toggle-calendar="$ctrl.toggleCalendar",
-    hidden-calendars="$ctrl.hiddenCalendars"
+    hidden-calendars="$ctrl.hiddenCalendars",
+    select-all-calendars="$ctrl.selectAllCalendars",
+    length-user-calendars="$ctrl.userCalendarsLength"
+
   )
 
   cal-external-calendars-list(
@@ -10,5 +13,7 @@
     shared-calendars="$ctrl.sharedCalendars",
     public-calendars="$ctrl.publicCalendars",
     toggle-calendar="$ctrl.toggleCalendar",
-    hidden-calendars="$ctrl.hiddenCalendars"
+    hidden-calendars="$ctrl.hiddenCalendars",
+    select-all-calendars="$ctrl.selectAllCalendars",
+    length-user-calendars="$ctrl.sharedCalendarsLength"
   )

--- a/src/linagora.esn.calendar/app/components/calendars-list/external/external-calendars-list.component.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/external/external-calendars-list.component.js
@@ -8,7 +8,10 @@
         sharedCalendars: '=',
         publicCalendars: '=',
         toggleCalendar: '=',
-        hiddenCalendars: '='
+        hiddenCalendars: '=',
+        selectAllCalendars: '=',
+        calendarType: '=',
+        lengthUserCalendars: '='
       }
     });
 })(angular);

--- a/src/linagora.esn.calendar/app/components/calendars-list/external/external-calendars-list.pug
+++ b/src/linagora.esn.calendar/app/components/calendars-list/external/external-calendars-list.pug
@@ -2,16 +2,16 @@
   .lv-item.calendar-item.calendar-header-title.hidden-md
     .media
       .pull-left
-        i.mdi.mdi-calendar
+        i.mdi.mdi-checkbox-multiple-blank-circle.all-calendars-selected
       .media-body
         .lv-title {{ 'Shared calendars' | translate }}
-  .lv-item.calendar-item.calendar-header-title-desktop.visible-md.clickable.toggle-submenu.waves-classic(esn-toggle)
+  .lv-item.calendar-item.calendar-header-title-desktop.visible-md.clickable.toggle-submenu.waves-classic
     .media
-      .badge-container
+      .badge-container(calendar-list-toggle)
         .caret-submenu
           i.mdi.mdi-menu-down
       .calendar-item-left
-        i.mdi.mdi-calendar
+        i.mdi(ng-class="!$ctrl.calendarsToggled? 'mdi-checkbox-multiple-blank-circle' : 'mdi-checkbox-multiple-blank-circle-outline'",ng-click="$ctrl.selectAllCalendars('sharedCalendars',$ctrl.calendarsToggled=!$ctrl.calendarsToggled)")
       .media-body
         .lv-title {{ 'Shared calendars' | translate }}
 
@@ -21,7 +21,10 @@
       toggle-calendar="$ctrl.toggleCalendar",
       hidden-calendars="$ctrl.hiddenCalendars",
       state-to-go="'calendar.external.shared'",
-      show-details="true"
+      show-details="true",
+      calendar-type="'sharedCalendars'",
+      length-user-calendars="$ctrl.lengthUserCalendars"
+
     )
 
     calendars-list-items(
@@ -29,5 +32,8 @@
       toggle-calendar="$ctrl.toggleCalendar",
       hidden-calendars="$ctrl.hiddenCalendars",
       state-to-go="'calendar.external.shared'",
-      show-details="true"
+      show-details="true",
+      calendar-type="'sharedCalendars'",
+      length-user-calendars="$ctrl.lengthUserCalendars"
+
     )

--- a/src/linagora.esn.calendar/app/components/calendars-list/items/calendars-list-items.component.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/items/calendars-list-items.component.js
@@ -6,10 +6,12 @@
       template: require('./calendars-list-items.pug'),
       controller: 'CalendarsListItemsController',
       bindings: {
-        calendars: '=?',
+        calendars: '=',
         toggleCalendar: '=?',
         hiddenCalendars: '=?',
-        showDetails: '=?'
+        showDetails: '=?',
+        calendarType: '=',
+        lengthUserCalendars: '='
       }
     });
 })(angular);

--- a/src/linagora.esn.calendar/app/components/calendars-list/items/calendars-list-items.pug
+++ b/src/linagora.esn.calendar/app/components/calendars-list/items/calendars-list-items.pug
@@ -1,7 +1,10 @@
 .calendar-list-items(ng-repeat="calendar in $ctrl.calendars track by calendar.uniqueId")
   cal-calendars-list-item(
+    calendars="$ctrl.calendars"
     calendar="calendar",
-    on-show-hide-toggle="$ctrl.toggleCalendar(calendar)",
-    selected="!$ctrl.hiddenCalendars[calendar.getUniqueId()]",
+    on-show-hide-toggle="$ctrl.toggleCalendar(calendar , $ctrl.calendarType , $ctrl.lengthUserCalendars)",
+    selected="!$ctrl.hiddenCalendars[$ctrl.calendarType+calendar.getUniqueId()]",
     show-details="$ctrl.showDetails"
+    calendar-type="$ctrl.calendarType",
+
   )

--- a/src/linagora.esn.calendar/app/components/calendars-list/items/item/calendars-list-item.component.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/items/item/calendars-list-item.component.js
@@ -6,10 +6,12 @@
       template: require('./calendars-list-item.pug'),
       controller: 'CalendarsListItemController',
       bindings: {
+        calendars: '=',
         calendar: '<',
         onShowHideToggle: '&',
         selected: '<',
-        showDetails: '<'
+        showDetails: '<',
+        calendarType: '<'
       }
     });
 })(angular);

--- a/src/linagora.esn.calendar/app/components/calendars-list/items/item/calendars-list-item.pug
+++ b/src/linagora.esn.calendar/app/components/calendars-list/items/item/calendars-list-item.pug
@@ -10,4 +10,4 @@
             .details(ng-if="$ctrl.details")
               span.ellipsis {{ ::$ctrl.details }}
       settings-overlay.settings(ng-click="$event.stopImmediatePropagation(); hideAside();", ui-sref-active-eq="selected")
-        cal-calendars-list-item-configuration(calendar-id="$ctrl.calendar.uniqueId")
+        cal-calendars-list-item-configuration(calendar-id="$ctrl.calendar.uniqueId",calendars="$ctrl.calendars")    

--- a/src/linagora.esn.calendar/app/components/calendars-list/items/item/configuration/calendars-list-item-configuration.component.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/items/item/configuration/calendars-list-item-configuration.component.js
@@ -6,7 +6,8 @@
       template: require('./configuration-list.pug'),
       controller: 'CalendarsListItemConfigurationController',
       bindings: {
-        calendarId: '='
+        calendarId: '=',
+        calendars: '='
       }
     });
 })(angular);

--- a/src/linagora.esn.calendar/app/components/calendars-list/items/item/configuration/calendars-list-item-configuration.controller.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/items/item/configuration/calendars-list-item-configuration.controller.js
@@ -4,7 +4,10 @@
   angular.module('esn.calendar')
     .controller('CalendarsListItemConfigurationController', CalendarsListItemConfigurationController);
 
-  function CalendarsListItemConfigurationController($state) {
+  function CalendarsListItemConfigurationController(
+    $state,
+    calendarVisibilityService
+  ) {
     var self = this;
 
     self.$onInit = $onInit;

--- a/src/linagora.esn.calendar/app/components/calendars-list/user/user-calendars-list.component.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/user/user-calendars-list.component.js
@@ -4,10 +4,14 @@
   angular.module('esn.calendar')
     .component('calUserCalendarsList', {
       template: require('./user-calendars-list.pug'),
+      controller: 'UserCalendarsListController',
       bindings: {
         userCalendars: '=',
         toggleCalendar: '=',
-        hiddenCalendars: '='
+        hiddenCalendars: '=',
+        selectAllCalendars: '=',
+        calendarsToggled: '<',
+        lengthUserCalendars:'='
       }
     });
 })(angular);

--- a/src/linagora.esn.calendar/app/components/calendars-list/user/user-calendars-list.controller.js
+++ b/src/linagora.esn.calendar/app/components/calendars-list/user/user-calendars-list.controller.js
@@ -1,0 +1,24 @@
+(function(angular) {
+  'use strict';
+
+  angular.module('esn.calendar')
+    .controller('UserCalendarsListController', UserCalendarsListController);
+
+  function UserCalendarsListController($state, $rootScope) {
+    var self = this;
+
+    self.$onInit = $onInit;
+
+    ///////////////
+
+    function $onInit() {
+      self.calendarType = 'userCalendars';
+      $rootScope.$on('calendarsAreHidden', verifyIfCalendarsIsHidden);
+
+    }
+
+    function verifyIfCalendarsIsHidden(event, data) {
+      self.calendarsToggled = data.hidden;
+    }
+  }
+})(angular);

--- a/src/linagora.esn.calendar/app/components/calendars-list/user/user-calendars-list.pug
+++ b/src/linagora.esn.calendar/app/components/calendars-list/user/user-calendars-list.pug
@@ -2,16 +2,16 @@
   .lv-item.calendar-item.calendar-header-title.hidden-md
     .media
       .pull-left
-        i.mdi.mdi-calendar
+        i.mdi.mdi-checkbox-multiple-blank-circle.all-calendars-selected
       .media-body
         .lv-title {{ 'My calendars' | translate }}
-  .lv-item.calendar-item.calendar-header-title-desktop.visible-md.clickable.toggle-submenu.waves-classic(esn-toggle)
+  .lv-item.calendar-item.calendar-header-title-desktop.visible-md.clickable.toggle-submenu.waves-classic
     .media
-      .badge-container
+      .badge-container(calendar-list-toggle)
         .caret-submenu
           i.mdi.mdi-menu-down
       .calendar-item-left
-        i.mdi.mdi-calendar
+          i.mdi(ng-class="!$ctrl.calendarsToggled? 'mdi-checkbox-multiple-blank-circle' : 'mdi-checkbox-multiple-blank-circle-outline'",ng-click="$ctrl.selectAllCalendars('userCalendars',$ctrl.calendarsToggled=!$ctrl.calendarsToggled)")
       .media-body
         .lv-title {{ 'My calendars' | translate }}
 
@@ -19,5 +19,7 @@
     calendars-list-items(
       calendars="$ctrl.userCalendars",
       toggle-calendar="$ctrl.toggleCalendar",
-      hidden-calendars="$ctrl.hiddenCalendars"
+      hidden-calendars="$ctrl.hiddenCalendars",
+      calendar-type='"userCalendars"',
+      length-user-calendars="$ctrl.lengthUserCalendars"
     )


### PR DESCRIPTION
Updated demo : 


https://user-images.githubusercontent.com/43316837/149741019-b7294a22-13bf-4303-933c-d8626b959b33.mp4


The solution:

The radio button of group list is active if at least one calendar is selected . The idea is to update the logic og toogle calendar with adding new params :

- CalendarType: to detect from any list item the toggle is received and activate the radio button concerned
- Length of calendar by type: we need to retreive the length from the parent component 

This update will affect : 

- the storage : all the calendars must be stored by their type 
- the toggle function : we must compare in each call the length calendars and the length of hidden one
- Th hidden calendars function : we must retreive this list by their type 

